### PR TITLE
Add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug Report
+about: Report something that isn't working correctly
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Describe the Bug
+
+A clear description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Enter '...'
+4. See error
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Screenshots
+
+If applicable, add screenshots to help explain the problem.
+
+## Environment
+
+- **Browser**: [e.g., Chrome 120, Firefox 121, Safari 17]
+- **OS**: [e.g., macOS 14, Windows 11, Ubuntu 22.04]
+- **Device**: [e.g., Desktop, iPad, iPhone]
+
+## Additional Context
+
+Add any other context about the problem here. If this involves a specific Markdown or Mermaid syntax, please include a minimal example.
+
+```markdown
+<!-- Paste minimal example here if relevant -->
+```

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://github.com/mickdarling/merdown/security/advisories/new
+    about: Report security vulnerabilities privately through GitHub Security Advisories
+  - name: Questions & Discussion
+    url: https://github.com/mickdarling/merdown/discussions
+    about: Ask questions or start a discussion (if Discussions is enabled)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem or Motivation
+
+Describe the problem you're trying to solve or why this feature would be valuable.
+
+## Proposed Solution
+
+A clear description of what you'd like to happen.
+
+## Alternatives Considered
+
+Any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, mockups, or examples about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+## Summary
+
+Brief description of what this PR does.
+
+## Related Issue
+
+Fixes #(issue number)
+
+<!-- Or use: Relates to #(issue number) if not fully fixing -->
+
+## Changes Made
+
+- Change 1
+- Change 2
+- Change 3
+
+## Testing Done
+
+Describe how you tested these changes:
+
+- [ ] Tested in Chrome
+- [ ] Tested in Firefox
+- [ ] Tested in Safari
+- [ ] Tested on mobile
+
+## Screenshots
+
+<!-- If applicable, add screenshots showing the changes -->
+
+## Checklist
+
+- [ ] My code follows the project's style
+- [ ] I have tested my changes locally
+- [ ] I have updated documentation if needed
+- [ ] My changes don't break existing functionality


### PR DESCRIPTION
## Summary

Adds standardized templates for issues and pull requests to improve contribution quality and consistency.

## Related Issue

Fixes #22

## Changes Made

### Issue Templates (`.github/ISSUE_TEMPLATE/`)

- **bug_report.md** - Structured bug reporting with:
  - Steps to reproduce
  - Expected vs actual behavior
  - Environment details (browser, OS, device)
  - Space for code examples

- **feature_request.md** - Feature proposals with:
  - Problem/motivation
  - Proposed solution
  - Alternatives considered

- **config.yml** - Template chooser configuration:
  - Allows blank issues for flexibility
  - Links to Security Advisories for vulnerability reports
  - Links to Discussions (if enabled)

### PR Template (`.github/PULL_REQUEST_TEMPLATE.md`)

- Summary section
- Related issue linking
- Changes made checklist
- Testing checklist (cross-browser)
- Screenshot placeholder
- Contribution checklist

## Testing Done

- [x] Verified YAML frontmatter syntax is valid
- [x] Confirmed labels match existing repo labels (`bug`, `enhancement`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)