### PR TITLE
Add missing editor theme CSS files

### DIFF
--- a/styles/editor/dracula.css
+++ b/styles/editor/dracula.css
@@ -1,0 +1,200 @@
+/* CodeMirror Editor Theme: Dracula
+ * Based on the Dracula color scheme
+ * Customize colors here - changes apply only to the editor
+ */
+
+/* Base editor styling */
+.cm-s-custom.CodeMirror {
+    background: #282a36;
+    color: #f8f8f2;
+}
+
+.cm-s-custom .CodeMirror-gutters {
+    background: #282a36;
+    border-right: 1px solid #44475a;
+    color: #6272a4;
+}
+
+.cm-s-custom .CodeMirror-linenumber {
+    color: #6272a4;
+}
+
+.cm-s-custom .CodeMirror-cursor {
+    border-left: 2px solid #f8f8f0;
+}
+
+.cm-s-custom .CodeMirror-selected {
+    background: #44475a;
+}
+
+.cm-s-custom .CodeMirror-activeline-background {
+    background: #343746;
+}
+
+/* Markdown syntax highlighting */
+.cm-s-custom .cm-header {
+    color: #ff79c6;
+    font-weight: bold;
+}
+
+/* Note: Removed font-size changes for headers - causes selection misalignment in CodeMirror */
+
+.cm-s-custom .cm-strong {
+    color: #ffb86c;
+    font-weight: bold;
+}
+
+.cm-s-custom .cm-em {
+    color: #bd93f9;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-link {
+    color: #8be9fd;
+    text-decoration: none;
+}
+
+.cm-s-custom .cm-url {
+    color: #8be9fd;
+}
+
+.cm-s-custom .cm-comment {
+    color: #f8f8f2;
+    font-style: normal;
+}
+
+/* Code block content - make it readable, not grayed out */
+.cm-s-custom .cm-comment.cm-m-markdown {
+    color: #f1fa8c;
+    font-style: normal;
+}
+
+.cm-s-custom .cm-quote {
+    color: #50fa7b;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-hr {
+    color: #6272a4;
+}
+
+.cm-s-custom .cm-strikethrough {
+    text-decoration: line-through;
+    color: #6272a4;
+}
+
+/* Code blocks in markdown */
+.cm-s-custom .cm-formatting-code-block,
+.cm-s-custom .cm-comment.cm-formatting-code-block {
+    color: #50fa7b;
+}
+
+/* Inline code */
+.cm-s-custom .cm-formatting-code,
+.cm-s-custom .cm-inline-code {
+    color: #50fa7b;
+    background: rgba(80, 250, 123, 0.1);
+}
+
+/* Lists */
+.cm-s-custom .cm-formatting-list,
+.cm-s-custom .cm-formatting-list-ul,
+.cm-s-custom .cm-formatting-list-ol {
+    color: #ff79c6;
+}
+
+/* Task lists */
+.cm-s-custom .cm-formatting-task {
+    color: #8be9fd;
+}
+
+/* Image/link brackets */
+.cm-s-custom .cm-formatting-link,
+.cm-s-custom .cm-formatting-image {
+    color: #8be9fd;
+}
+
+/* Blockquote marker */
+.cm-s-custom .cm-formatting-quote {
+    color: #50fa7b;
+}
+
+/* Keyword highlighting */
+.cm-s-custom .cm-keyword {
+    color: #ff79c6;
+}
+
+.cm-s-custom .cm-atom {
+    color: #bd93f9;
+}
+
+.cm-s-custom .cm-number {
+    color: #bd93f9;
+}
+
+.cm-s-custom .cm-def {
+    color: #50fa7b;
+}
+
+.cm-s-custom .cm-variable {
+    color: #f8f8f2;
+}
+
+.cm-s-custom .cm-variable-2 {
+    color: #f8f8f2;
+}
+
+.cm-s-custom .cm-variable-3 {
+    color: #8be9fd;
+}
+
+.cm-s-custom .cm-property {
+    color: #50fa7b;
+}
+
+.cm-s-custom .cm-operator {
+    color: #ff79c6;
+}
+
+.cm-s-custom .cm-string {
+    color: #f1fa8c;
+}
+
+.cm-s-custom .cm-string-2 {
+    color: #f1fa8c;
+}
+
+.cm-s-custom .cm-meta {
+    color: #f8f8f2;
+}
+
+.cm-s-custom .cm-tag {
+    color: #ff79c6;
+}
+
+.cm-s-custom .cm-attribute {
+    color: #50fa7b;
+}
+
+.cm-s-custom .cm-builtin {
+    color: #8be9fd;
+}
+
+.cm-s-custom .cm-bracket {
+    color: #f8f8f2;
+}
+
+/* Search highlighting */
+.cm-s-custom .cm-searching {
+    background: rgba(241, 250, 140, 0.4);
+}
+
+/* Matching brackets */
+.cm-s-custom .CodeMirror-matchingbracket {
+    color: #50fa7b !important;
+    background: rgba(80, 250, 123, 0.2);
+}
+
+.cm-s-custom .CodeMirror-nonmatchingbracket {
+    color: #ff5555 !important;
+}

--- a/styles/editor/github-dark.css
+++ b/styles/editor/github-dark.css
@@ -1,0 +1,200 @@
+/* CodeMirror Editor Theme: GitHub Dark
+ * Based on GitHub's dark theme colors
+ * Customize colors here - changes apply only to the editor
+ */
+
+/* Base editor styling */
+.cm-s-custom.CodeMirror {
+    background: #0d1117;
+    color: #c9d1d9;
+}
+
+.cm-s-custom .CodeMirror-gutters {
+    background: #0d1117;
+    border-right: 1px solid #30363d;
+    color: #6e7681;
+}
+
+.cm-s-custom .CodeMirror-linenumber {
+    color: #6e7681;
+}
+
+.cm-s-custom .CodeMirror-cursor {
+    border-left: 2px solid #58a6ff;
+}
+
+.cm-s-custom .CodeMirror-selected {
+    background: #264f78;
+}
+
+.cm-s-custom .CodeMirror-activeline-background {
+    background: #161b22;
+}
+
+/* Markdown syntax highlighting */
+.cm-s-custom .cm-header {
+    color: #58a6ff;
+    font-weight: bold;
+}
+
+/* Note: Removed font-size changes for headers - causes selection misalignment in CodeMirror */
+
+.cm-s-custom .cm-strong {
+    color: #f0883e;
+    font-weight: bold;
+}
+
+.cm-s-custom .cm-em {
+    color: #d2a8ff;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-link {
+    color: #58a6ff;
+    text-decoration: none;
+}
+
+.cm-s-custom .cm-url {
+    color: #a5d6ff;
+}
+
+.cm-s-custom .cm-comment {
+    color: #c9d1d9;
+    font-style: normal;
+}
+
+/* Code block content - make it readable, not grayed out */
+.cm-s-custom .cm-comment.cm-m-markdown {
+    color: #ffa657;
+    font-style: normal;
+}
+
+.cm-s-custom .cm-quote {
+    color: #7ee787;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-hr {
+    color: #30363d;
+}
+
+.cm-s-custom .cm-strikethrough {
+    text-decoration: line-through;
+    color: #8b949e;
+}
+
+/* Code blocks in markdown */
+.cm-s-custom .cm-formatting-code-block,
+.cm-s-custom .cm-comment.cm-formatting-code-block {
+    color: #7ee787;
+}
+
+/* Inline code */
+.cm-s-custom .cm-formatting-code,
+.cm-s-custom .cm-inline-code {
+    color: #7ee787;
+    background: rgba(126, 231, 135, 0.1);
+}
+
+/* Lists */
+.cm-s-custom .cm-formatting-list,
+.cm-s-custom .cm-formatting-list-ul,
+.cm-s-custom .cm-formatting-list-ol {
+    color: #f0883e;
+}
+
+/* Task lists */
+.cm-s-custom .cm-formatting-task {
+    color: #58a6ff;
+}
+
+/* Image/link brackets */
+.cm-s-custom .cm-formatting-link,
+.cm-s-custom .cm-formatting-image {
+    color: #58a6ff;
+}
+
+/* Blockquote marker */
+.cm-s-custom .cm-formatting-quote {
+    color: #7ee787;
+}
+
+/* Keyword highlighting */
+.cm-s-custom .cm-keyword {
+    color: #ff7b72;
+}
+
+.cm-s-custom .cm-atom {
+    color: #79c0ff;
+}
+
+.cm-s-custom .cm-number {
+    color: #79c0ff;
+}
+
+.cm-s-custom .cm-def {
+    color: #d2a8ff;
+}
+
+.cm-s-custom .cm-variable {
+    color: #ffa657;
+}
+
+.cm-s-custom .cm-variable-2 {
+    color: #ffa657;
+}
+
+.cm-s-custom .cm-variable-3 {
+    color: #79c0ff;
+}
+
+.cm-s-custom .cm-property {
+    color: #79c0ff;
+}
+
+.cm-s-custom .cm-operator {
+    color: #ff7b72;
+}
+
+.cm-s-custom .cm-string {
+    color: #a5d6ff;
+}
+
+.cm-s-custom .cm-string-2 {
+    color: #a5d6ff;
+}
+
+.cm-s-custom .cm-meta {
+    color: #c9d1d9;
+}
+
+.cm-s-custom .cm-tag {
+    color: #7ee787;
+}
+
+.cm-s-custom .cm-attribute {
+    color: #79c0ff;
+}
+
+.cm-s-custom .cm-builtin {
+    color: #ffa657;
+}
+
+.cm-s-custom .cm-bracket {
+    color: #c9d1d9;
+}
+
+/* Search highlighting */
+.cm-s-custom .cm-searching {
+    background: rgba(210, 153, 34, 0.4);
+}
+
+/* Matching brackets */
+.cm-s-custom .CodeMirror-matchingbracket {
+    color: #7ee787 !important;
+    background: rgba(126, 231, 135, 0.2);
+}
+
+.cm-s-custom .CodeMirror-nonmatchingbracket {
+    color: #ff7b72 !important;
+}

--- a/styles/editor/material-darker.css
+++ b/styles/editor/material-darker.css
@@ -1,0 +1,200 @@
+/* CodeMirror Editor Theme: Material Darker
+ * Based on Material Darker color scheme
+ * Customize colors here - changes apply only to the editor
+ */
+
+/* Base editor styling */
+.cm-s-custom.CodeMirror {
+    background: #282c34;
+    color: #abb2bf;
+}
+
+.cm-s-custom .CodeMirror-gutters {
+    background: #21252b;
+    border-right: 1px solid #3a3f4b;
+    color: #636d83;
+}
+
+.cm-s-custom .CodeMirror-linenumber {
+    color: #636d83;
+}
+
+.cm-s-custom .CodeMirror-cursor {
+    border-left: 2px solid #528bff;
+}
+
+.cm-s-custom .CodeMirror-selected {
+    background: #3e4451;
+}
+
+.cm-s-custom .CodeMirror-activeline-background {
+    background: #2c323c;
+}
+
+/* Markdown syntax highlighting */
+.cm-s-custom .cm-header {
+    color: #e06c75;
+    font-weight: bold;
+}
+
+/* Note: Removed font-size changes for headers - causes selection misalignment in CodeMirror */
+
+.cm-s-custom .cm-strong {
+    color: #d19a66;
+    font-weight: bold;
+}
+
+.cm-s-custom .cm-em {
+    color: #c678dd;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-link {
+    color: #61afef;
+    text-decoration: none;
+}
+
+.cm-s-custom .cm-url {
+    color: #56b6c2;
+}
+
+.cm-s-custom .cm-comment {
+    color: #abb2bf;
+    font-style: normal;
+}
+
+/* Code block content - make it readable, not grayed out */
+.cm-s-custom .cm-comment.cm-m-markdown {
+    color: #e5c07b;
+    font-style: normal;
+}
+
+.cm-s-custom .cm-quote {
+    color: #98c379;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-hr {
+    color: #56b6c2;
+}
+
+.cm-s-custom .cm-strikethrough {
+    text-decoration: line-through;
+    color: #636d83;
+}
+
+/* Code blocks in markdown */
+.cm-s-custom .cm-formatting-code-block,
+.cm-s-custom .cm-comment.cm-formatting-code-block {
+    color: #98c379;
+}
+
+/* Inline code */
+.cm-s-custom .cm-formatting-code,
+.cm-s-custom .cm-inline-code {
+    color: #98c379;
+    background: rgba(152, 195, 121, 0.1);
+}
+
+/* Lists */
+.cm-s-custom .cm-formatting-list,
+.cm-s-custom .cm-formatting-list-ul,
+.cm-s-custom .cm-formatting-list-ol {
+    color: #e06c75;
+}
+
+/* Task lists */
+.cm-s-custom .cm-formatting-task {
+    color: #61afef;
+}
+
+/* Image/link brackets */
+.cm-s-custom .cm-formatting-link,
+.cm-s-custom .cm-formatting-image {
+    color: #61afef;
+}
+
+/* Blockquote marker */
+.cm-s-custom .cm-formatting-quote {
+    color: #98c379;
+}
+
+/* Keyword highlighting (for fenced code blocks language) */
+.cm-s-custom .cm-keyword {
+    color: #c678dd;
+}
+
+.cm-s-custom .cm-atom {
+    color: #d19a66;
+}
+
+.cm-s-custom .cm-number {
+    color: #d19a66;
+}
+
+.cm-s-custom .cm-def {
+    color: #61afef;
+}
+
+.cm-s-custom .cm-variable {
+    color: #e06c75;
+}
+
+.cm-s-custom .cm-variable-2 {
+    color: #e06c75;
+}
+
+.cm-s-custom .cm-variable-3 {
+    color: #56b6c2;
+}
+
+.cm-s-custom .cm-property {
+    color: #e06c75;
+}
+
+.cm-s-custom .cm-operator {
+    color: #56b6c2;
+}
+
+.cm-s-custom .cm-string {
+    color: #98c379;
+}
+
+.cm-s-custom .cm-string-2 {
+    color: #98c379;
+}
+
+.cm-s-custom .cm-meta {
+    color: #abb2bf;
+}
+
+.cm-s-custom .cm-tag {
+    color: #e06c75;
+}
+
+.cm-s-custom .cm-attribute {
+    color: #d19a66;
+}
+
+.cm-s-custom .cm-builtin {
+    color: #56b6c2;
+}
+
+.cm-s-custom .cm-bracket {
+    color: #abb2bf;
+}
+
+/* Search highlighting */
+.cm-s-custom .cm-searching {
+    background: rgba(255, 255, 0, 0.3);
+}
+
+/* Matching brackets */
+.cm-s-custom .CodeMirror-matchingbracket {
+    color: #98c379 !important;
+    background: rgba(152, 195, 121, 0.2);
+}
+
+.cm-s-custom .CodeMirror-nonmatchingbracket {
+    color: #e06c75 !important;
+}

--- a/styles/editor/monokai.css
+++ b/styles/editor/monokai.css
@@ -1,0 +1,200 @@
+/* CodeMirror Editor Theme: Monokai
+ * Based on the classic Monokai color scheme
+ * Customize colors here - changes apply only to the editor
+ */
+
+/* Base editor styling */
+.cm-s-custom.CodeMirror {
+    background: #272822;
+    color: #f8f8f2;
+}
+
+.cm-s-custom .CodeMirror-gutters {
+    background: #272822;
+    border-right: 1px solid #49483e;
+    color: #75715e;
+}
+
+.cm-s-custom .CodeMirror-linenumber {
+    color: #75715e;
+}
+
+.cm-s-custom .CodeMirror-cursor {
+    border-left: 2px solid #f8f8f0;
+}
+
+.cm-s-custom .CodeMirror-selected {
+    background: #49483e;
+}
+
+.cm-s-custom .CodeMirror-activeline-background {
+    background: #3e3d32;
+}
+
+/* Markdown syntax highlighting */
+.cm-s-custom .cm-header {
+    color: #f92672;
+    font-weight: bold;
+}
+
+/* Note: Removed font-size changes for headers - causes selection misalignment in CodeMirror */
+
+.cm-s-custom .cm-strong {
+    color: #fd971f;
+    font-weight: bold;
+}
+
+.cm-s-custom .cm-em {
+    color: #ae81ff;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-link {
+    color: #66d9ef;
+    text-decoration: none;
+}
+
+.cm-s-custom .cm-url {
+    color: #66d9ef;
+}
+
+.cm-s-custom .cm-comment {
+    color: #f8f8f2;
+    font-style: normal;
+}
+
+/* Code block content - make it readable, not grayed out */
+.cm-s-custom .cm-comment.cm-m-markdown {
+    color: #e6db74;
+    font-style: normal;
+}
+
+.cm-s-custom .cm-quote {
+    color: #a6e22e;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-hr {
+    color: #75715e;
+}
+
+.cm-s-custom .cm-strikethrough {
+    text-decoration: line-through;
+    color: #75715e;
+}
+
+/* Code blocks in markdown */
+.cm-s-custom .cm-formatting-code-block,
+.cm-s-custom .cm-comment.cm-formatting-code-block {
+    color: #a6e22e;
+}
+
+/* Inline code */
+.cm-s-custom .cm-formatting-code,
+.cm-s-custom .cm-inline-code {
+    color: #a6e22e;
+    background: rgba(166, 226, 46, 0.1);
+}
+
+/* Lists */
+.cm-s-custom .cm-formatting-list,
+.cm-s-custom .cm-formatting-list-ul,
+.cm-s-custom .cm-formatting-list-ol {
+    color: #f92672;
+}
+
+/* Task lists */
+.cm-s-custom .cm-formatting-task {
+    color: #66d9ef;
+}
+
+/* Image/link brackets */
+.cm-s-custom .cm-formatting-link,
+.cm-s-custom .cm-formatting-image {
+    color: #66d9ef;
+}
+
+/* Blockquote marker */
+.cm-s-custom .cm-formatting-quote {
+    color: #a6e22e;
+}
+
+/* Keyword highlighting */
+.cm-s-custom .cm-keyword {
+    color: #f92672;
+}
+
+.cm-s-custom .cm-atom {
+    color: #ae81ff;
+}
+
+.cm-s-custom .cm-number {
+    color: #ae81ff;
+}
+
+.cm-s-custom .cm-def {
+    color: #a6e22e;
+}
+
+.cm-s-custom .cm-variable {
+    color: #f8f8f2;
+}
+
+.cm-s-custom .cm-variable-2 {
+    color: #f8f8f2;
+}
+
+.cm-s-custom .cm-variable-3 {
+    color: #66d9ef;
+}
+
+.cm-s-custom .cm-property {
+    color: #a6e22e;
+}
+
+.cm-s-custom .cm-operator {
+    color: #f92672;
+}
+
+.cm-s-custom .cm-string {
+    color: #e6db74;
+}
+
+.cm-s-custom .cm-string-2 {
+    color: #e6db74;
+}
+
+.cm-s-custom .cm-meta {
+    color: #f8f8f2;
+}
+
+.cm-s-custom .cm-tag {
+    color: #f92672;
+}
+
+.cm-s-custom .cm-attribute {
+    color: #a6e22e;
+}
+
+.cm-s-custom .cm-builtin {
+    color: #66d9ef;
+}
+
+.cm-s-custom .cm-bracket {
+    color: #f8f8f2;
+}
+
+/* Search highlighting */
+.cm-s-custom .cm-searching {
+    background: rgba(230, 219, 116, 0.4);
+}
+
+/* Matching brackets */
+.cm-s-custom .CodeMirror-matchingbracket {
+    color: #a6e22e !important;
+    background: rgba(166, 226, 46, 0.2);
+}
+
+.cm-s-custom .CodeMirror-nonmatchingbracket {
+    color: #f92672 !important;
+}

--- a/styles/editor/solarized-dark.css
+++ b/styles/editor/solarized-dark.css
@@ -1,0 +1,200 @@
+/* CodeMirror Editor Theme: Solarized Dark
+ * Based on Ethan Schoonover's Solarized color scheme
+ * Customize colors here - changes apply only to the editor
+ */
+
+/* Base editor styling */
+.cm-s-custom.CodeMirror {
+    background: #002b36;
+    color: #839496;
+}
+
+.cm-s-custom .CodeMirror-gutters {
+    background: #002b36;
+    border-right: 1px solid #073642;
+    color: #586e75;
+}
+
+.cm-s-custom .CodeMirror-linenumber {
+    color: #586e75;
+}
+
+.cm-s-custom .CodeMirror-cursor {
+    border-left: 2px solid #839496;
+}
+
+.cm-s-custom .CodeMirror-selected {
+    background: #073642;
+}
+
+.cm-s-custom .CodeMirror-activeline-background {
+    background: #073642;
+}
+
+/* Markdown syntax highlighting */
+.cm-s-custom .cm-header {
+    color: #cb4b16;
+    font-weight: bold;
+}
+
+/* Note: Removed font-size changes for headers - causes selection misalignment in CodeMirror */
+
+.cm-s-custom .cm-strong {
+    color: #b58900;
+    font-weight: bold;
+}
+
+.cm-s-custom .cm-em {
+    color: #6c71c4;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-link {
+    color: #268bd2;
+    text-decoration: none;
+}
+
+.cm-s-custom .cm-url {
+    color: #2aa198;
+}
+
+.cm-s-custom .cm-comment {
+    color: #839496;
+    font-style: normal;
+}
+
+/* Code block content - make it readable, not grayed out */
+.cm-s-custom .cm-comment.cm-m-markdown {
+    color: #b58900;
+    font-style: normal;
+}
+
+.cm-s-custom .cm-quote {
+    color: #859900;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-hr {
+    color: #586e75;
+}
+
+.cm-s-custom .cm-strikethrough {
+    text-decoration: line-through;
+    color: #586e75;
+}
+
+/* Code blocks in markdown */
+.cm-s-custom .cm-formatting-code-block,
+.cm-s-custom .cm-comment.cm-formatting-code-block {
+    color: #859900;
+}
+
+/* Inline code */
+.cm-s-custom .cm-formatting-code,
+.cm-s-custom .cm-inline-code {
+    color: #859900;
+    background: rgba(133, 153, 0, 0.1);
+}
+
+/* Lists */
+.cm-s-custom .cm-formatting-list,
+.cm-s-custom .cm-formatting-list-ul,
+.cm-s-custom .cm-formatting-list-ol {
+    color: #cb4b16;
+}
+
+/* Task lists */
+.cm-s-custom .cm-formatting-task {
+    color: #268bd2;
+}
+
+/* Image/link brackets */
+.cm-s-custom .cm-formatting-link,
+.cm-s-custom .cm-formatting-image {
+    color: #268bd2;
+}
+
+/* Blockquote marker */
+.cm-s-custom .cm-formatting-quote {
+    color: #859900;
+}
+
+/* Keyword highlighting */
+.cm-s-custom .cm-keyword {
+    color: #859900;
+}
+
+.cm-s-custom .cm-atom {
+    color: #d33682;
+}
+
+.cm-s-custom .cm-number {
+    color: #d33682;
+}
+
+.cm-s-custom .cm-def {
+    color: #268bd2;
+}
+
+.cm-s-custom .cm-variable {
+    color: #839496;
+}
+
+.cm-s-custom .cm-variable-2 {
+    color: #268bd2;
+}
+
+.cm-s-custom .cm-variable-3 {
+    color: #2aa198;
+}
+
+.cm-s-custom .cm-property {
+    color: #268bd2;
+}
+
+.cm-s-custom .cm-operator {
+    color: #859900;
+}
+
+.cm-s-custom .cm-string {
+    color: #2aa198;
+}
+
+.cm-s-custom .cm-string-2 {
+    color: #cb4b16;
+}
+
+.cm-s-custom .cm-meta {
+    color: #839496;
+}
+
+.cm-s-custom .cm-tag {
+    color: #268bd2;
+}
+
+.cm-s-custom .cm-attribute {
+    color: #b58900;
+}
+
+.cm-s-custom .cm-builtin {
+    color: #dc322f;
+}
+
+.cm-s-custom .cm-bracket {
+    color: #839496;
+}
+
+/* Search highlighting */
+.cm-s-custom .cm-searching {
+    background: rgba(181, 137, 0, 0.4);
+}
+
+/* Matching brackets */
+.cm-s-custom .CodeMirror-matchingbracket {
+    color: #859900 !important;
+    background: rgba(133, 153, 0, 0.2);
+}
+
+.cm-s-custom .CodeMirror-nonmatchingbracket {
+    color: #dc322f !important;
+}

--- a/styles/editor/solarized-light.css
+++ b/styles/editor/solarized-light.css
@@ -1,0 +1,200 @@
+/* CodeMirror Editor Theme: Solarized Light
+ * Based on Ethan Schoonover's Solarized color scheme
+ * Customize colors here - changes apply only to the editor
+ */
+
+/* Base editor styling */
+.cm-s-custom.CodeMirror {
+    background: #fdf6e3;
+    color: #657b83;
+}
+
+.cm-s-custom .CodeMirror-gutters {
+    background: #fdf6e3;
+    border-right: 1px solid #eee8d5;
+    color: #93a1a1;
+}
+
+.cm-s-custom .CodeMirror-linenumber {
+    color: #93a1a1;
+}
+
+.cm-s-custom .CodeMirror-cursor {
+    border-left: 2px solid #657b83;
+}
+
+.cm-s-custom .CodeMirror-selected {
+    background: #eee8d5;
+}
+
+.cm-s-custom .CodeMirror-activeline-background {
+    background: #eee8d5;
+}
+
+/* Markdown syntax highlighting */
+.cm-s-custom .cm-header {
+    color: #cb4b16;
+    font-weight: bold;
+}
+
+/* Note: Removed font-size changes for headers - causes selection misalignment in CodeMirror */
+
+.cm-s-custom .cm-strong {
+    color: #b58900;
+    font-weight: bold;
+}
+
+.cm-s-custom .cm-em {
+    color: #6c71c4;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-link {
+    color: #268bd2;
+    text-decoration: none;
+}
+
+.cm-s-custom .cm-url {
+    color: #2aa198;
+}
+
+.cm-s-custom .cm-comment {
+    color: #657b83;
+    font-style: normal;
+}
+
+/* Code block content - make it readable, not grayed out */
+.cm-s-custom .cm-comment.cm-m-markdown {
+    color: #b58900;
+    font-style: normal;
+}
+
+.cm-s-custom .cm-quote {
+    color: #859900;
+    font-style: italic;
+}
+
+.cm-s-custom .cm-hr {
+    color: #93a1a1;
+}
+
+.cm-s-custom .cm-strikethrough {
+    text-decoration: line-through;
+    color: #93a1a1;
+}
+
+/* Code blocks in markdown */
+.cm-s-custom .cm-formatting-code-block,
+.cm-s-custom .cm-comment.cm-formatting-code-block {
+    color: #859900;
+}
+
+/* Inline code */
+.cm-s-custom .cm-formatting-code,
+.cm-s-custom .cm-inline-code {
+    color: #859900;
+    background: rgba(133, 153, 0, 0.1);
+}
+
+/* Lists */
+.cm-s-custom .cm-formatting-list,
+.cm-s-custom .cm-formatting-list-ul,
+.cm-s-custom .cm-formatting-list-ol {
+    color: #cb4b16;
+}
+
+/* Task lists */
+.cm-s-custom .cm-formatting-task {
+    color: #268bd2;
+}
+
+/* Image/link brackets */
+.cm-s-custom .cm-formatting-link,
+.cm-s-custom .cm-formatting-image {
+    color: #268bd2;
+}
+
+/* Blockquote marker */
+.cm-s-custom .cm-formatting-quote {
+    color: #859900;
+}
+
+/* Keyword highlighting */
+.cm-s-custom .cm-keyword {
+    color: #859900;
+}
+
+.cm-s-custom .cm-atom {
+    color: #d33682;
+}
+
+.cm-s-custom .cm-number {
+    color: #d33682;
+}
+
+.cm-s-custom .cm-def {
+    color: #268bd2;
+}
+
+.cm-s-custom .cm-variable {
+    color: #657b83;
+}
+
+.cm-s-custom .cm-variable-2 {
+    color: #268bd2;
+}
+
+.cm-s-custom .cm-variable-3 {
+    color: #2aa198;
+}
+
+.cm-s-custom .cm-property {
+    color: #268bd2;
+}
+
+.cm-s-custom .cm-operator {
+    color: #859900;
+}
+
+.cm-s-custom .cm-string {
+    color: #2aa198;
+}
+
+.cm-s-custom .cm-string-2 {
+    color: #cb4b16;
+}
+
+.cm-s-custom .cm-meta {
+    color: #657b83;
+}
+
+.cm-s-custom .cm-tag {
+    color: #268bd2;
+}
+
+.cm-s-custom .cm-attribute {
+    color: #b58900;
+}
+
+.cm-s-custom .cm-builtin {
+    color: #dc322f;
+}
+
+.cm-s-custom .cm-bracket {
+    color: #657b83;
+}
+
+/* Search highlighting */
+.cm-s-custom .cm-searching {
+    background: rgba(181, 137, 0, 0.3);
+}
+
+/* Matching brackets */
+.cm-s-custom .CodeMirror-matchingbracket {
+    color: #859900 !important;
+    background: rgba(133, 153, 0, 0.2);
+}
+
+.cm-s-custom .CodeMirror-nonmatchingbracket {
+    color: #dc322f !important;
+}


### PR DESCRIPTION
## Summary

Fixes broken editor styling on GitHub Pages deployment. The CodeMirror editor theme CSS files were never committed to the repository.

## Problem

The editor was displaying with a dark background and black text (unreadable) because the `styles/editor/*.css` files only existed locally.

## Changes Made

Added 6 editor theme CSS files:
- `material-darker.css` (default theme)
- `github-dark.css`
- `monokai.css`
- `dracula.css`
- `solarized-dark.css`
- `solarized-light.css`

## Testing

After merge, verify at https://mickdarling.github.io/merdown/ that:
- [ ] Editor has proper syntax highlighting
- [ ] Theme dropdown changes editor appearance
- [ ] All 6 themes work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)