### PR TITLE
security: Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,13 +27,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@6337623ebba10cf8c8214b507993f8062fd4ccfb # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |


### PR DESCRIPTION
## Summary
- Pin GitHub Actions to immutable SHA hashes instead of mutable version tags
- Fixes SonarCloud security hotspot (githubactions:S7637)

## Changes
| Action | Before | After |
|--------|--------|-------|
| actions/checkout | `@v4` | `@34e114876b0b11c390a56381ad16ebd13914f8d5` |
| anthropics/claude-code-action | `@v1` | `@6337623ebba10cf8c8214b507993f8062fd4ccfb` |

## Why This Matters
Using version tags like `@v1` is convenient but creates supply chain risk - tags are mutable and can be moved to point at different (potentially malicious) code. SHA hashes are immutable and guarantee you run exactly the code you reviewed.

Version comments (`# v1`) are preserved for readability.

## Test plan
- [x] Verify workflow file syntax is valid
- [ ] PR triggers Claude Code Review action successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)