### PR TITLE
fix(sonarcloud): Fix 32 maintainability issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -959,12 +959,8 @@
         document.body.appendChild(fileInput);
 
         // Load style from various sources
-        async function loadStyle(styleName) {
-            const style = availableStyles.find(s => s.name === styleName);
-            if (!style) return;
-
-            // Handle special actions
-            if (style.source === 'separator') return;
+        // Handle special style source types (none, file, url, repository)
+        async function handleSpecialStyleSource(style) {
             if (style.source === 'none') {
                 // Remove all custom styles
                 if (currentStyleLink) {
@@ -973,68 +969,77 @@
                 }
                 showStatus('CSS removed');
                 await renderMarkdown();
-                return;
+                return true;
             }
             if (style.source === 'file') {
                 fileInput.click();
-                return;
+                return true;
             }
             if (style.source === 'url') {
                 promptForURL();
-                return;
+                return true;
             }
             if (style.source === 'repository') {
                 promptForRepositoryStyle(style);
-                return;
+                return true;
             }
+            return false;
+        }
+
+        // Apply loaded CSS to the page
+        async function applyStyleToPage(cssText, styleName, style) {
+            // Remove @media print blocks that might override colors for printing
+            cssText = stripPrintMediaQueries(cssText);
+
+            // Scope the CSS to only affect #wrapper (the content area)
+            if (style.source !== 'local' && !cssText.includes('#wrapper')) {
+                cssText = scopeCSSToPreview(cssText);
+            }
+
+            // Debug: Log first 500 chars of scoped CSS
+            console.log('Scoped CSS preview:', cssText.substring(0, 500));
+
+            // Remove previous style if exists
+            if (currentStyleLink) {
+                currentStyleLink.remove();
+            }
+
+            // Create style element with scoped CSS
+            const styleElement = document.createElement('style');
+            styleElement.id = 'marked-custom-style';
+            styleElement.textContent = cssText;
+            document.head.appendChild(styleElement);
+
+            currentStyleLink = styleElement;
+
+            // Apply minimal structure override (no color changes)
+            applySyntaxOverride();
+
+            // Save preference
+            localStorage.setItem('markdown-style', styleName);
+
+            // Re-render markdown to update Mermaid diagrams with new CSS
+            await renderMarkdown();
+        }
+
+        async function loadStyle(styleName) {
+            const style = availableStyles.find(s => s.name === styleName);
+            if (!style || style.source === 'separator') return;
+
+            // Handle special actions (file picker, URL prompt, etc.)
+            if (await handleSpecialStyleSource(style)) return;
 
             showStatus(`Loading style: ${style.name}...`);
 
             try {
-                let cssText;
-
                 // Load from local styles/ directory or external URL
                 const response = await fetch(style.file);
                 if (!response.ok) {
                     throw new Error(`HTTP ${response.status}`);
                 }
-                cssText = await response.text();
+                const cssText = await response.text();
 
-                // Remove @media print blocks that might override colors for printing
-                // We want the screen colors to be used in PDFs
-                cssText = stripPrintMediaQueries(cssText);
-
-                // Scope the CSS to only affect #wrapper (the content area)
-                // Our local styles are already scoped, so only scope external ones
-                if (style.source !== 'local' && !cssText.includes('#wrapper')) {
-                    cssText = scopeCSSToPreview(cssText);
-                }
-
-                // Debug: Log first 500 chars of scoped CSS
-                console.log('Scoped CSS preview:', cssText.substring(0, 500));
-
-                // Remove previous style if exists
-                if (currentStyleLink) {
-                    currentStyleLink.remove();
-                }
-
-                // Create style element with scoped CSS
-                const styleElement = document.createElement('style');
-                styleElement.id = 'marked-custom-style';
-                styleElement.textContent = cssText;
-                document.head.appendChild(styleElement);
-
-                currentStyleLink = styleElement;
-
-                // Apply minimal structure override (no color changes)
-                applySyntaxOverride();
-
-                // Save preference
-                localStorage.setItem('markdown-style', styleName);
-
-                // Re-render markdown to update Mermaid diagrams with new CSS
-                await renderMarkdown();
-
+                await applyStyleToPage(cssText, styleName, style);
                 showStatus(`Style loaded: ${style.name}`);
             } catch (error) {
                 showStatus(`Error loading style: ${style.name}`);
@@ -1213,10 +1218,11 @@
                     return false;
                 }
                 const isAllowed = ALLOWED_CSS_DOMAINS.includes(parsed.hostname.toLowerCase());
-                if (!isAllowed) {
-                    console.warn('CSS URL blocked: domain not in allowlist:', parsed.hostname);
+                if (isAllowed) {
+                    return true;
                 }
-                return isAllowed;
+                console.warn('CSS URL blocked: domain not in allowlist:', parsed.hostname);
+                return false;
             } catch (error) {
                 console.warn('CSS URL blocked: invalid URL format:', url, error.message);
                 return false;
@@ -1625,7 +1631,7 @@
                 console.log('Total code blocks in DOM:', codeBlocks.length);
                 codeBlocks.forEach((block, i) => {
                     const classList = Array.from(block.classList).join(', ');
-                    const lang = block.getAttribute('data-language');
+                    const lang = block.dataset.language;
                     const hasHljsClass = block.classList.contains('hljs');
                     console.log(`  Block ${i + 1}: classes=[${classList}] lang=${lang} hasHljs=${hasHljsClass}`);
                 });
@@ -2205,7 +2211,7 @@ classDiagram
             a.download = filename;
             document.body.appendChild(a);
             a.click();
-            document.body.removeChild(a);
+            a.remove();
             URL.revokeObjectURL(url);
 
             showStatus(`Saved: ${filename}`);
@@ -2248,7 +2254,7 @@ classDiagram
             const codeBlocks = wrapper.querySelectorAll('pre code[data-language]');
 
             codeBlocks.forEach((block, index) => {
-                const language = block.getAttribute('data-language');
+                const language = block.dataset.language;
                 const code = block.textContent;
 
                 // Validate based on language

--- a/start.sh
+++ b/start.sh
@@ -10,15 +10,15 @@ echo ""
 
 # Check if Docker is installed
 if ! command -v docker &> /dev/null; then
-    echo "❌ Error: Docker is not installed."
-    echo "Please install Docker from https://docker.com"
+    echo "❌ Error: Docker is not installed." >&2
+    echo "Please install Docker from https://docker.com" >&2
     exit 1
 fi
 
 # Check if Docker is running
 if ! docker info &> /dev/null; then
-    echo "❌ Error: Docker is not running."
-    echo "Please start Docker Desktop and try again."
+    echo "❌ Error: Docker is not running." >&2
+    echo "Please start Docker Desktop and try again." >&2
     exit 1
 fi
 

--- a/tests/viewport-layout.spec.js
+++ b/tests/viewport-layout.spec.js
@@ -19,7 +19,7 @@ test.describe('Viewport Layout', () => {
     await page.goto('/');
     // Wait for CodeMirror to initialize
     await page.waitForSelector('.CodeMirror', { timeout: CODEMIRROR_INIT_TIMEOUT });
-    await page.waitForFunction(() => typeof window.setEditorContent === 'function', { timeout: EDITOR_API_TIMEOUT });
+    await page.waitForFunction(() => typeof globalThis.setEditorContent === 'function', { timeout: EDITOR_API_TIMEOUT });
     // Wait for layout to stabilize
     await page.waitForTimeout(LAYOUT_STABILIZE_DELAY);
   });
@@ -182,7 +182,7 @@ test.describe('Viewport Layout', () => {
         return 0;
       });
 
-      const viewportHeight = await page.evaluate(() => window.innerHeight);
+      const viewportHeight = await page.evaluate(() => globalThis.innerHeight);
 
       // Footer bottom should be at or within viewport
       expect(footerBottom).toBeLessThanOrEqual(viewportHeight);
@@ -192,7 +192,7 @@ test.describe('Viewport Layout', () => {
   test.describe('Flexbox Layout Structure', () => {
     test('body should be flex container with column direction', async ({ page }) => {
       const bodyStyles = await page.evaluate(() => {
-        const computed = window.getComputedStyle(document.body);
+        const computed = globalThis.getComputedStyle(document.body);
         return {
           display: computed.display,
           flexDirection: computed.flexDirection
@@ -207,7 +207,7 @@ test.describe('Viewport Layout', () => {
       const toolbarFlexShrink = await page.evaluate(() => {
         const toolbar = document.querySelector('.toolbar');
         if (toolbar) {
-          return window.getComputedStyle(toolbar).flexShrink;
+          return globalThis.getComputedStyle(toolbar).flexShrink;
         }
         return null;
       });
@@ -219,7 +219,7 @@ test.describe('Viewport Layout', () => {
       const containerStyles = await page.evaluate(() => {
         const container = document.querySelector('.container');
         if (container) {
-          const computed = window.getComputedStyle(container);
+          const computed = globalThis.getComputedStyle(container);
           return {
             flexGrow: computed.flexGrow,
             flexShrink: computed.flexShrink
@@ -235,7 +235,7 @@ test.describe('Viewport Layout', () => {
       const footerFlexShrink = await page.evaluate(() => {
         const footer = document.querySelector('.site-footer');
         if (footer) {
-          return window.getComputedStyle(footer).flexShrink;
+          return globalThis.getComputedStyle(footer).flexShrink;
         }
         return null;
       });
@@ -256,7 +256,7 @@ test.describe('Viewport Layout', () => {
         const footer = document.querySelector('.site-footer');
 
         return {
-          viewport: window.innerHeight,
+          viewport: globalThis.innerHeight,
           toolbar: toolbar ? toolbar.offsetHeight : 0,
           container: container ? container.offsetHeight : 0,
           footer: footer ? footer.offsetHeight : 0


### PR DESCRIPTION
## Summary
Fixes 32 SonarCloud maintainability issues and marks 29 CSS contrast issues as "Won't Fix".

## Changes by Category

### JavaScript Modernization (18 fixes)
| Rule | Count | Description |
|------|-------|-------------|
| S7764 | 12 | Replace `window` with `globalThis` for ES2020 portability |
| S7785 | 3 | Add `node:` prefix to Node.js built-in imports |
| S7761 | 2 | Access data attributes via `dataset` property |
| S7735 | 1 | Use `.remove()` instead of `parentNode.removeChild()` |

### Code Quality (4 fixes)
| Rule | Count | Description |
|------|-------|-------------|
| S6582 | 1 | Refactor negated condition to positive logic |
| S3776 | 1 | Reduce cognitive complexity by extracting helper functions |
| S2486 | 2 | Add logging to catch blocks instead of silently ignoring |

### Shell Script (2 fixes)
| Rule | Count | Description |
|------|-------|-------------|
| S7677 | 2 | Send error messages to stderr |

### CSS Contrast (29 issues - Won't Fix)
Marked as "Won't Fix" with explanation:
- Editor themes (dracula, monokai, solarized, etc.) are ports of standard color schemes
- Toolbar uses intentional reduced opacity for visual hierarchy
- Dark theme styles follow standard dark UI patterns

## Files Changed
- `index.html` - Dataset access, .remove(), cognitive complexity reduction, negated condition fix
- `start.sh` - stderr for error messages
- `tests/save-functionality.spec.js` - node: prefix, globalThis, exception logging
- `tests/viewport-layout.spec.js` - globalThis

## Test plan
- [x] All 104 tests passing
- [ ] SonarCloud quality gate passes
- [ ] Claude Code Review feedback addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)