### PR TITLE
fix: Keep URL parameter visible for sharing/bookmarking

### DIFF
--- a/docs/session-notes-2025-12-03-dark-mode-fix.md
+++ b/docs/session-notes-2025-12-03-dark-mode-fix.md
@@ -1,0 +1,193 @@
+# Session Notes: Dark Mode Preview Fix & Theme Improvements
+
+**Date:** December 3, 2025 (Afternoon ~4 PM)
+**Duration:** ~2 hours
+**Focus:** Fix Dark Mode preview background, add layout toggle, fix editor theme backgrounds
+
+---
+
+## Summary
+
+Fixed issue #10 (Dark Mode preview theme has inconsistent text colors) and discovered/fixed additional theme-related issues. Added a "Respect Style Layout" toggle for users who want loaded styles to control layout. Created follow-up issues for remaining work.
+
+---
+
+## Completed Tasks
+
+### 1. Merged PR #75 - SonarCloud Maintainability Issues
+- Verified all 10 issues were addressed in the existing PR
+- All checks passed (SonarCloud Quality Gate + Claude Review)
+- Merged to main, deleted branch
+
+### 2. Fixed Dark Mode Preview Background (Issue #10)
+
+**Root Cause:**
+- `#preview` container had `background: white !important` hardcoded
+- `#wrapper` had `all: initial` which reset styles from loaded themes
+- CSS specificity: `#preview #wrapper` (specificity 200) beat `#wrapper` (specificity 100) from loaded styles
+
+**Solution:**
+- Added `applyPreviewBackground(cssText)` function that:
+  - Parses loaded CSS for `#wrapper { background: ... }`
+  - Extracts background color value
+  - Applies it to `#preview` container via JavaScript
+- Removed `!important` from `#preview` background
+- Simplified `#wrapper` base styles
+
+### 3. Added "Respect Style Layout" Toggle
+
+**Feature:** New option in Style dropdown to control layout behavior
+- **OFF (default):** Preview fills full width, user controls via drag handle
+- **ON:** Loaded styles can apply their own max-width, margins, gutters
+
+**Implementation:**
+- Added toggle entry in `availableStyles` array with `source: 'toggle'`
+- Shows checkmark when enabled: `☐ Respect Style Layout` / `✓ Respect Style Layout`
+- State persisted in localStorage
+- `applyLayoutConstraints()` function applies/removes overrides
+
+### 4. Fixed Editor Theme Backgrounds
+
+**Issue:** Solarized Light and Solarized Dark looked nearly identical (both dark)
+
+**Root Cause:** Base CSS had hardcoded `#282c34` backgrounds with high-specificity selectors:
+```css
+#editor-container .CodeMirror { background: #282c34; }
+```
+This overrode theme CSS which uses `.cm-s-custom.CodeMirror`
+
+**Solution:** Removed hardcoded backgrounds from base CSS, letting theme CSS control colors
+
+### 5. Addressed Code Review Feedback
+
+**SonarCloud (3 issues):**
+- Changed `parseInt()` to `Number.parseInt()` with radix parameter
+
+**Claude Review improvements:**
+- Added JSDoc comments to new functions
+- Added null guards for `preview` and `wrapper` elements
+- Documented CSS parsing limitations (gradients, CSS variables fall back to white)
+- Replaced `waitForTimeout(500)` with `waitForFunction()` for reliable tests
+- Tests now check semantic values (dark < 50, light > 240) not exact RGB
+
+---
+
+## Pull Requests
+
+### PR #77 - Fix Dark Mode Preview Background
+- **Status:** Open, ready for final review
+- **Files changed:** `index.html`, `tests/dark-mode-background.spec.js`
+- **Tests:** 109 passing (5 new tests added)
+- **Closes:** Issue #10
+
+---
+
+## Issues Created
+
+### Issue #76 - Add test coverage for CSS helper functions
+- Follow-up from PR #75 code review
+- Nice-to-have: Unit tests for `stripPrintMediaQueries` helper functions
+
+### Issue #78 - Sync editor and code block theme options for full parity
+- Editor has 6 themes, code blocks have 12 themes
+- Goal: Both dropdowns should offer the same themes
+- Tasks:
+  - Add 4 highlight.js themes (Material Darker, Dracula, Solarized Dark/Light from base16/)
+  - Create 10 CodeMirror theme CSS files (GitHub Light, VS Code Dark+, Atom One Dark/Light, Nord, Tokyo Night Dark/Light, Night Owl, Obsidian, Agate)
+
+---
+
+## Technical Details
+
+### Theme Systems
+
+**Editor (CodeMirror 5):**
+- Local CSS files in `styles/editor/*.css`
+- Classes: `.cm-s-custom`, `.cm-keyword`, etc.
+- 6 themes currently
+
+**Code Blocks (highlight.js):**
+- CDN: `cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/`
+- Classes: `.hljs`, `.hljs-keyword`, etc.
+- 12 themes currently
+- Some themes in `base16/` subdirectory
+
+### CSS Parsing for Background Extraction
+
+```javascript
+// Regex to find #wrapper background
+const wrapperMatch = cssText.match(/#wrapper\s*\{[^}]*\}/);
+const bgMatch = wrapperRule.match(/background(?:-color)?\s*:\s*([^;}\s]+)/);
+```
+
+**Limitations:** Complex backgrounds (gradients, CSS variables) may not extract correctly - falls back to white.
+
+---
+
+## Test Results
+
+- **109 tests passing** (5 new tests for dark mode)
+- New tests verify:
+  - Dark background applied when Dark Mode selected
+  - Switching between light/dark styles works
+  - Wrapper element inherits correct background
+  - Layout constraints (max-width: none, margin: 0)
+  - Text readability in dark mode
+
+---
+
+## Files Changed This Session
+
+| File | Changes |
+|------|---------|
+| `index.html` | Dark mode fix, layout toggle, editor theme fix, JSDoc |
+| `tests/dark-mode-background.spec.js` | New test file (5 tests) |
+| `docs/session-notes-2025-12-03-dark-mode-fix.md` | This file |
+
+---
+
+## Next Steps for Next Session
+
+### Immediate (PR #77)
+1. Wait for CI checks to pass on latest commit
+2. Review any new feedback from Claude Review bot
+3. Merge PR #77 to main
+4. Close issue #10
+
+### Follow-up Work
+1. **Issue #78 - Theme Parity** (priority)
+   - Start with highlight.js additions (config-only changes)
+   - Then create CodeMirror theme CSS files
+   - Generate SRI hashes for new CDN themes
+
+2. **Issue #76 - CSS Helper Tests** (nice-to-have)
+   - Add unit tests for `isPrintMediaStart`, `skipToOpeningBrace`, `processInsidePrintMedia`
+
+3. **Continue through open issues** (oldest first)
+   - Issue #11: Add Mermaid diagram theme selector
+   - Issue #13: Add loading indicator and size limit for file loading
+   - Issue #17: Review and update README for public release
+
+---
+
+## Commands Reference
+
+```bash
+# Run tests
+npx playwright test --reporter=list
+
+# Start Docker for manual testing
+docker compose up -d --build
+# App available at http://localhost:8081
+
+# Check SonarCloud issues for PR
+SONAR_TOKEN=$(security find-generic-password -s "sonar_token2" -w)
+curl -s -H "Authorization: Bearer $SONAR_TOKEN" \
+  "https://sonarcloud.io/api/issues/search?projects=mickdarling_merview&pullRequest=77"
+```
+
+---
+
+**End of Session**
+
+*Dark Mode fix complete, layout toggle added, editor themes fixed, PR ready for merge*

--- a/docs/session-notes-2025-12-04-url-sharing.md
+++ b/docs/session-notes-2025-12-04-url-sharing.md
@@ -1,0 +1,111 @@
+# Session Notes: URL Sharing Feature (Phase 1)
+**Date:** December 4, 2025
+**Session ID:** merview-session-2025-12-04-url-sharing
+
+## Summary
+
+Implemented Phase 1 of the URL sharing feature (#79) - ability to load markdown documents from GitHub via `?url=` parameter. PR #80 created but paused due to SonarCloud code duplication issues.
+
+## What Was Accomplished
+
+### Feature Implementation
+- Added `?url=` parameter support for loading remote markdown
+- Domain allowlist: `raw.githubusercontent.com`, `gist.githubusercontent.com`
+- HTTPS-only enforcement
+- URL parameter cleared after successful load (history.replaceState)
+- Content saves to localStorage like any other document
+
+### Files Modified
+- `index.html` - Added URL loading functions and init logic (~80 lines)
+- `tests/url-loading.spec.js` - New test file with 13 tests (~280 lines)
+
+### Commits in PR #80
+1. `feat: Add URL parameter support for loading remote markdown`
+2. `fix: Use globalThis instead of window for SonarCloud compliance`
+3. `test: Add comprehensive URL loading test coverage`
+4. `fix(sonarcloud): Address code smells and security hotspots in tests`
+
+### Issues Created (from code review)
+- #81 - Improve error recovery UX for URL loading failures
+- #82 - Add URL validation edge case protections
+- #83 - Add Content-Type validation for remote markdown loading
+- #84 - Refactor URL validation to reduce code duplication
+- #85 - Add fetch timeout and content size limits for URL loading
+- #86 - Add documentation for URL parameter sharing feature
+
+## Current Status: PAUSED
+
+### Blocking Issue
+**SonarCloud reports massive code duplication** in the test file. The Quality Gate is failing due to duplication metrics.
+
+The test file has repetitive patterns:
+- Multiple `await page.goto('/')` + `await page.waitForSelector('.CodeMirror', ...)` blocks
+- Similar `page.evaluate()` patterns for testing URL validation
+- Repeated status checking patterns
+
+### Next Steps Required
+1. **Refactor test file to reduce duplication:**
+   - Add `test.beforeEach` hook for common setup
+   - Create helper functions for repeated patterns
+   - Consider data-driven tests where applicable
+
+2. **After duplication is fixed:**
+   - Push changes
+   - Verify SonarCloud Quality Gate passes
+   - Merge PR #80
+
+3. **Future work (Phase 2):**
+   - "Share to Gist" button with GitHub OAuth (#79)
+
+## Technical Details
+
+### New Functions Added to index.html
+```javascript
+// Line ~1351
+const ALLOWED_MARKDOWN_DOMAINS = [
+    'raw.githubusercontent.com',
+    'gist.githubusercontent.com'
+];
+
+// Line ~1377
+function isAllowedMarkdownURL(url) { ... }
+globalThis.isAllowedMarkdownURL = isAllowedMarkdownURL; // for testing
+
+// Line ~1398
+async function loadMarkdownFromURL(url) { ... }
+```
+
+### URL Parameter Handling (DOMContentLoaded)
+```javascript
+const urlParams = new URLSearchParams(globalThis.location.search);
+const remoteURL = urlParams.get('url');
+
+if (remoteURL) {
+    loadMarkdownFromURL(remoteURL).then(success => {
+        if (success) {
+            globalThis.history.replaceState({}, '', globalThis.location.pathname);
+        }
+    });
+} else {
+    // existing localStorage/sample loading
+}
+```
+
+### Test Structure (needs refactoring)
+- Domain Allowlist Validation (3 tests)
+- HTTPS Enforcement (2 tests)
+- Invalid URL Handling (1 test)
+- URL Parameter Clearing (2 tests)
+- Status Messages (1 test)
+- Error Handling (2 tests)
+- No URL Parameter Behavior (2 tests)
+
+## Environment Notes
+- Docker container `merview-preview` on port 8080 (nginx)
+- http-server on port 8081 for Playwright tests
+- Playwright MCP runs in Docker, needs `host.docker.internal` to reach host
+
+## Related Documentation
+- Issue #79: Original feature request
+- PR #80: Current implementation (paused)
+- Previous session: `merview-session-2025-12-03-evening` (dark mode fix)

--- a/index.html
+++ b/index.html
@@ -2780,12 +2780,8 @@ classDiagram
 
             if (remoteURL) {
                 // Load from URL parameter
-                loadMarkdownFromURL(remoteURL).then(success => {
-                    if (success) {
-                        // Clear URL param so refresh uses localStorage (their edited version)
-                        globalThis.history.replaceState({}, '', globalThis.location.pathname);
-                    }
-                });
+                // URL is kept in browser bar so users can share/bookmark the link
+                loadMarkdownFromURL(remoteURL);
             } else {
                 // Load saved content or sample
                 const saved = localStorage.getItem('markdown-content');

--- a/tests/url-loading.spec.js
+++ b/tests/url-loading.spec.js
@@ -115,18 +115,18 @@ test.describe('URL Loading', () => {
     });
   });
 
-  test.describe('URL Parameter Clearing', () => {
+  test.describe('URL Parameter Behavior', () => {
     // Common test URL used across multiple tests
     const TEST_README_URL = 'https://raw.githubusercontent.com/mickdarling/merview/main/README.md';
 
-    test('should clear URL parameter after successful load', async ({ page }) => {
+    test('should retain URL parameter after successful load for sharing/bookmarking', async ({ page }) => {
       await page.goto(`/?url=${encodeURIComponent(TEST_README_URL)}`);
       await page.waitForSelector('.CodeMirror', { timeout: 15000 });
+      await waitForStatusContaining(page, 'Loaded', 15000);
 
-      // Wait for the async load to complete and URL to be cleared
-      await page.waitForFunction(() => !globalThis.location.search.includes('url='), { timeout: 10000 });
-
-      expect(page.url()).not.toContain('url=');
+      // URL should still contain the parameter for sharing/bookmarking
+      expect(page.url()).toContain('url=');
+      expect(page.url()).toContain(encodeURIComponent(TEST_README_URL));
     });
 
     test('should load content from URL parameter', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Keep `?url=` parameter in browser bar after loading remote document
- Enables users to share/bookmark the URL

## Changes
- Removed `history.replaceState()` call that cleared the URL parameter
- Updated test to verify URL is retained instead of cleared

## Test Plan
- [x] All 16 URL loading tests pass
- [x] Verified URL stays in browser bar after load
- [x] Can copy URL and share with others

Fixes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)