### PR TITLE
security: Add fetch timeout and content size limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Block URLs with embedded credentials (user:pass@host) to prevent credential leakage
   - Enforce 2048 character URL length limit to prevent DoS attacks
   - Block IDN/punycode homograph attacks by rejecting non-ASCII hostnames
+- Add fetch timeout and content size limits for URL loading (#85)
+  - 10-second timeout prevents app hanging on slow/unresponsive endpoints
+  - 10MB content size limit prevents loading extremely large files
+  - User-friendly error messages for timeout and size limit violations
 
 ### Changed
 - Fresh visits to merview.com now load the sample document instead of cached content (#137)


### PR DESCRIPTION
## Summary

Adds performance safeguards to `loadMarkdownFromURL()` to prevent DoS risks from slow endpoints or large files:

- **10-second fetch timeout** - Uses AbortController to prevent hanging on slow/unresponsive endpoints
- **10MB content size limit** - Two-layer defense checking both Content-Length header and actual content size

Fixes #85

## Changes

### `js/file-ops.js`
- Added `FETCH_TIMEOUT_MS` constant (10000ms)
- Added `MAX_CONTENT_SIZE` constant (10MB)
- Implemented AbortController with timeout for fetch
- Added Content-Length header check before download
- Added actual content size check after download
- Improved error handling with user-friendly messages:
  - "Request timed out (10s limit)"
  - "File too large (XMB, max 10MB)"

### `tests/url-loading.spec.js`
- Added 4 new tests in "Fetch Timeout and Size Limits (Issue #85)" describe block
- Tests verify AbortController mechanism, normal file loading, error logging, and error messages

### `CHANGELOG.md`
- Added Security section documenting the new protections

## Test plan

- [x] All 395 tests pass
- [x] Normal file loading still works
- [x] Error paths properly handle failures
- [ ] Manual testing with slow endpoint (optional)
- [ ] Manual testing with large file (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)