### PR TITLE
feat: Toggle horizontal rule as page break in PDF export

### DIFF
--- a/index.html
+++ b/index.html
@@ -1006,16 +1006,9 @@
             }
 
             /* Page break support for slide decks and paginated documents */
-            /* Horizontal rules (<hr> from ---) trigger new pages */
-            #wrapper hr {
-                page-break-after: always;
-                break-after: page;
-                border: none;
-                margin: 0;
-                padding: 0;
-                visibility: hidden;
-                height: 0;
-            }
+            /* Note: HR page break behavior is now controlled by a toggle in the Options menu.
+               The CSS is dynamically injected by JavaScript in themes.js based on user preference.
+               Default: enabled (preserves backward compatibility with existing documents). */
 
             /* Respect all CSS page-break properties */
             #wrapper [style*="page-break-before: always"],

--- a/js/config.js
+++ b/js/config.js
@@ -106,6 +106,7 @@ export const availableStyles = [
     { name: 'Monospace', file: 'styles/monospace.css', source: 'local', group: 'Preview Style' },
     { name: 'Newspaper', file: 'styles/newspaper.css', source: 'local', group: 'Preview Style' },
     { name: 'Respect Style Layout', file: '', source: 'toggle', group: 'Options' },
+    { name: 'HR as Page Break', file: '', source: 'toggle', group: 'Options' },
     { name: 'Load from file...', file: '', source: 'file', group: 'Import' },
     { name: 'Load from URL...', file: '', source: 'url', group: 'Import' },
     { name: 'MarkedCustomStyles (external)', file: '', source: 'repository',

--- a/js/state.js
+++ b/js/state.js
@@ -47,6 +47,8 @@ export const state = {
 
     // Layout state
     respectStyleLayout: localStorage.getItem('respect-style-layout') === 'true', // Whether to respect loaded style's layout constraints
+    hrAsPageBreak: localStorage.getItem('hr-page-break') !== 'false', // Whether horizontal rules trigger page breaks in PDF (default: true)
+    hrPageBreakToggleOption: null,       // Cached reference to HR page break toggle option (performance)
 
     // GitHub Gist OAuth state
     gistAuthState: {

--- a/js/storage.js
+++ b/js/storage.js
@@ -102,6 +102,24 @@ export function saveRespectStyleLayout(respectLayout) {
 }
 
 /**
+ * Get "HR as Page Break" toggle preference
+ * @returns {boolean} True if horizontal rules should trigger page breaks (default: true)
+ */
+export function getHRAsPageBreak() {
+    const stored = localStorage.getItem('hr-page-break');
+    // Default to true if not set (preserves current behavior)
+    return stored === null ? true : stored === 'true';
+}
+
+/**
+ * Save "HR as Page Break" toggle preference
+ * @param {boolean} enabled - Whether horizontal rules should trigger page breaks
+ */
+export function saveHRAsPageBreak(enabled) {
+    localStorage.setItem('hr-page-break', enabled);
+}
+
+/**
  * Get stored GitHub access token for Gist functionality
  * @returns {string|null} Access token or null if expired/invalid
  */


### PR DESCRIPTION
## Summary
- Adds toggle to control whether `---` horizontal rules act as page breaks in PDF
- Persists user preference in localStorage
- Default behavior: enabled (preserves backward compatibility)

## Changes
- **js/storage.js**: Add `getHRAsPageBreak()` and `saveHRAsPageBreak()` functions
- **js/state.js**: Add `hrAsPageBreak` state and `hrPageBreakToggleOption` cache reference
- **js/config.js**: Add "HR as Page Break" toggle option to availableStyles (Options group)
- **js/themes.js**: 
  - Implement toggle logic in `changeStyle()`
  - Add `updateHRPageBreakToggleCheckbox()` for checkbox state updates
  - Add `applyHRPageBreakStyle()` to dynamically inject/remove @media print CSS
  - Initialize toggle state in `initStyleSelector()`
- **index.html**: Remove hardcoded HR page break CSS (now managed dynamically)

## Implementation Details

### Toggle UI
- Located in Style dropdown under "Options" group
- Uses checkbox pattern: ✓ (enabled) or ☐ (disabled)
- Follows same pattern as existing "Respect Style Layout" toggle

### CSS Management
- When **enabled** (default): Dynamically injects `<style id="hr-page-break-style">` with @media print rules
- When **disabled**: Removes the style element
- HR elements render as normal horizontal lines without page breaks

### Backward Compatibility
- Default state is `true` (enabled) to preserve existing document behavior
- Users who rely on `---` for page breaks will see no change
- Users who want visual separators can disable the toggle

## Test Plan
1. Open Merview in a new browser (fresh state)
2. Verify "HR as Page Break" toggle shows ✓ (enabled by default)
3. Create a document with horizontal rules:
   ```markdown
   # Page 1
   Content
   ---
   # Page 2
   More content
   ```
4. Export to PDF with toggle ON - verify HRs create page breaks
5. Toggle OFF - verify status shows "HR as visual separator enabled"
6. Export to PDF with toggle OFF - verify HRs render as lines without page breaks
7. Refresh page - verify setting persists (localStorage)
8. Toggle back ON - verify status shows "HR as page break enabled"
9. Export to PDF - verify page breaks work again

## Screenshots
(Will be added during testing)

Fixes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>