### PR TITLE
fix: Add user feedback for storage quota exceeded

### DIFF
--- a/index.html
+++ b/index.html
@@ -827,6 +827,10 @@
             background: #e67e22;
         }
 
+        .status.error {
+            background: #e74c3c;
+        }
+
         .lint-panel {
             position: fixed;
             bottom: -300px;

--- a/js/utils.js
+++ b/js/utils.js
@@ -125,20 +125,22 @@ export function isDarkColor(colorString) {
 /**
  * Show status message to user
  * @param {string} message - Message to display
- * @param {string} type - Message type ('success' or 'warning')
+ * @param {string} type - Message type ('success', 'warning', or 'error')
  */
 export function showStatus(message, type = 'success') {
     const { statusDiv } = getElements();
     statusDiv.textContent = message;
-    statusDiv.classList.remove('warning');
+    statusDiv.classList.remove('warning', 'error');
     if (type === 'warning') {
         statusDiv.classList.add('warning');
+    } else if (type === 'error') {
+        statusDiv.classList.add('error');
     }
     statusDiv.classList.add('show');
-    // Warnings show longer (6s) than success messages (3s)
-    const duration = type === 'warning' ? 6000 : 3000;
+    // Errors and warnings show longer (6s) than success messages (3s)
+    const duration = (type === 'warning' || type === 'error') ? 6000 : 3000;
     setTimeout(() => {
-        statusDiv.classList.remove('show', 'warning');
+        statusDiv.classList.remove('show', 'warning', 'error');
     }, duration);
 }
 


### PR DESCRIPTION
## Summary
- Shows user-friendly error notifications when localStorage quota is exceeded
- Enhanced showStatus() function to properly support 'error' type messages
- Added red error styling to match the existing warning (orange) and success (green) styles

## Changes
- **js/utils.js**: Enhanced showStatus() to support 'error' type (red background, 6s duration)
- **index.html**: Added CSS styling for .status.error class

## Background
The sessions.js file already had user-facing notifications for storage quota errors (lines 172 and 243), but the showStatus() function didn't properly support the 'error' type. When storage quota is exceeded:

1. System attempts auto-cleanup of old sessions
2. If cleanup succeeds: Shows warning message about cleaned-up sessions
3. If cleanup fails: Shows error message suggesting user delete sessions manually

## Testing
The error notifications will now display correctly with:
- Red background color (#e74c3c)
- 6-second duration (same as warnings)
- Proper message: "Storage quota exceeded. Please delete some sessions to continue."

Fixes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)