### PR TITLE
fix: Prevent Mermaid theme flash on back navigation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -7,7 +7,7 @@
 import { state } from './state.js';
 import { initCodeMirror, getEditorContent, setEditorContent } from './editor.js';
 import { renderMarkdown, scheduleRender } from './renderer.js';
-import { initStyleSelector, initSyntaxThemeSelector, initEditorThemeSelector, initMermaidThemeSelector, initPreviewDragDrop, initURLModalHandlers, changeStyle, changeSyntaxTheme, changeEditorTheme, changeMermaidTheme, applyPreviewBackground } from './themes.js';
+import { initStyleSelector, initSyntaxThemeSelector, initEditorThemeSelector, initMermaidThemeSelector, initPreviewDragDrop, initURLModalHandlers, changeStyle, changeSyntaxTheme, changeEditorTheme, changeMermaidTheme, applyPreviewBackground, applyCachedBackground } from './themes.js';
 import { loadMarkdownFromURL, loadSample, openFile, saveFile, saveFileAs, isValidMarkdownFile, isValidMarkdownContentType, exportToPDF, initFileInputHandlers } from './file-ops.js';
 import { initDocumentSelector, changeDocument, updateDocumentSelector } from './documents.js';
 import { shareToGist, hideGistModal, openGitHubAuth, startDeviceFlow, copyGistUrl, disconnectGitHub } from './gist.js';
@@ -291,6 +291,10 @@ function initializeApp() {
 
     // Initialize CodeMirror with scheduleRender as the change callback
     initCodeMirror(scheduleRender);
+
+    // Apply cached background early to prevent Mermaid theme flash on back navigation (#175 fix)
+    // This must happen BEFORE any theme initialization or rendering
+    applyCachedBackground();
 
     // Initialize theme selectors
     // IMPORTANT: Mermaid theme must be initialized BEFORE style selector,

--- a/js/storage.js
+++ b/js/storage.js
@@ -219,3 +219,21 @@ export function isFreshVisit() {
 export function markSessionInitialized() {
     sessionStorage.setItem(SESSION_INITIALIZED_KEY, 'true');
 }
+
+/**
+ * Get cached preview background color
+ * Used to prevent Mermaid theme flash on back navigation (issue #175)
+ * @returns {string|null} Cached background color or null
+ */
+export function getCachedBackgroundColor() {
+    return localStorage.getItem('cached-bg-color');
+}
+
+/**
+ * Save preview background color to cache
+ * Used to prevent Mermaid theme flash on back navigation (issue #175)
+ * @param {string} bgColor - Background color to cache
+ */
+export function saveCachedBackgroundColor(bgColor) {
+    localStorage.setItem('cached-bg-color', bgColor);
+}


### PR DESCRIPTION
## Summary
- Fixes race condition where Mermaid renders before theme detection on back navigation
- Caches the preview background color in localStorage and applies it early during initialization
- Ensures Mermaid theme is correct immediately on page load

## Root Cause
When using browser back button, the page loads from cache and Mermaid diagrams can render before the background color is detected from the CSS. This causes a brief flash of the default/light theme before the dark theme is applied.

## Solution
1. **Cache the background color**: Whenever a style is applied and background color is detected, save it to localStorage
2. **Apply cached color early**: On page initialization, before any theme loading or rendering, apply the cached background color
3. **Set Mermaid theme immediately**: The cached color triggers the correct Mermaid theme before any diagrams render

## Changes
- **js/storage.js**: Added `getCachedBackgroundColor()` and `saveCachedBackgroundColor()` functions
- **js/themes.js**: 
  - Added `applyCachedBackground()` function for early initialization
  - Cache background color in `applyPreviewBackground()`, `applyCSSCore()`
  - Export `applyCachedBackground` for use in main.js
- **js/main.js**: Call `applyCachedBackground()` early in `initializeApp()`, before any theme initialization

## Test Plan
1. Open Merview with a dark mode style and Mermaid "Auto" theme
2. Navigate to a page with Mermaid diagrams
3. Use browser back button to return
4. **Expected**: Diagrams should render with dark theme immediately, no flash of light theme
5. **Before fix**: Light theme would briefly flash before switching to dark

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)