### PR TITLE
chore: Reconcile isResizing and layoutToggleOption state management

### DIFF
--- a/js/resize.js
+++ b/js/resize.js
@@ -6,7 +6,11 @@
 
 import { getElements } from './dom.js';
 
-// Track resize state
+// Track resize state (module-local)
+// Note: This is intentionally NOT in state.js because:
+// - It's only used within this module (startResize, handleResize, stopResize)
+// - No other modules need to read or write this value
+// - Keeping it local reduces coupling and makes the code easier to reason about
 let isResizing = false;
 
 /**

--- a/js/state.js
+++ b/js/state.js
@@ -47,10 +47,6 @@ export const state = {
 
     // Layout state
     respectStyleLayout: localStorage.getItem('respect-style-layout') === 'true', // Whether to respect loaded style's layout constraints
-    layoutToggleOption: null,            // Cached reference to layout toggle option (performance)
-
-    // Panel resize state
-    isResizing: false,                   // Whether user is actively dragging resize handle
 
     // GitHub Gist OAuth state
     gistAuthState: {

--- a/js/themes.js
+++ b/js/themes.js
@@ -23,7 +23,11 @@ function isDebugMermaidTheme() {
     return localStorage.getItem('debug-mermaid-theme') === 'true';
 }
 
-// Local state for theme management
+// Local state for theme management (module-local)
+// Note: These are intentionally NOT in state.js because:
+// - They're only used within this module for UI caching and file uploads
+// - No other modules need to read or write these values
+// - Keeping them local reduces coupling and makes the code easier to reason about
 let layoutToggleOption = null; // Cached reference for performance
 let fileInput = null; // Hidden file input for CSS uploads
 


### PR DESCRIPTION
## Summary
- Removes unused `isResizing` and `layoutToggleOption` properties from centralized `state.js`
- Adds comprehensive documentation to module-local variables explaining why they remain local
- Improves code clarity by eliminating duplicate state definitions

## Analysis
The issue identified two cases of duplicate state management:

**Issue 1: `isResizing`**
- Defined in `state.js:53` but never accessed via `state.isResizing`
- Only used locally within `resize.js` module
- No other modules need access to this value

**Issue 2: `layoutToggleOption`**
- Defined in `state.js:50` but never accessed via `state.layoutToggleOption`
- Only used locally within `themes.js` for UI caching
- No other modules need access to this value

## Changes
- **js/state.js**: Removed unused `isResizing` and `layoutToggleOption` properties
- **js/resize.js**: Added documentation explaining why `isResizing` is module-local
- **js/themes.js**: Added documentation explaining why `layoutToggleOption` and `fileInput` are module-local

## Approach
Chose to remove unused properties from centralized state rather than migrate local variables, because:
1. These variables are truly module-local - no cross-module access needed
2. Keeping them local reduces coupling between modules
3. Makes the code easier to reason about and maintain
4. Aligns with the principle that state.js should only contain state that's shared across modules

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)