### PR TITLE
fix: Add Learn More link to private URL security modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1095,6 +1095,7 @@
             <div class="security-icon" aria-hidden="true">🔒</div>
             <h2 id="privateUrlModalTitle">Private Repository Detected</h2>
             <p id="privateUrlModalDesc">This URL contains a private access token. To protect your security, choose how you'd like to proceed:</p>
+            <p style="margin: 8px 0 12px 0; font-size: 12px;"><a href="/?url=SECURITY.md#private-repository-token-protection" target="_blank" rel="noopener noreferrer" style="color: #3498db; text-decoration: none;">Learn more about private repo tokens</a></p>
             <div class="option-buttons">
                 <button class="option-btn" data-action="view-local" type="button" aria-label="View Locally Only - Render content without a shareable URL">
                     <span class="option-title">View Locally Only</span>


### PR DESCRIPTION
## Summary
- Adds "Learn more about private repo tokens" link to the private repository security modal
- Links to SECURITY.md documentation explaining GitHub token handling and security implications

## Changes
- Modified `/Users/mick/Developer/markdown-mermaid-renderer/index.html`:
  - Added a subtle "Learn more" link below the modal's descriptive text
  - Link opens SECURITY.md in a new tab at the "Private Repository Token Protection" section
  - Styled as small, non-intrusive text to complement the main modal options

## Testing
- All existing private URL modal tests pass (46/46)
- Link follows security best practices with `target="_blank"` and `rel="noopener noreferrer"`

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>