### PR TITLE
refactor: Move YAML front matter inline styles to CSS classes (fixes #236)

### DIFF
--- a/index.html
+++ b/index.html
@@ -830,6 +830,14 @@
             background: rgba(0,0,0,0.08) !important;
         }
 
+        .yaml-front-matter .yaml-icon {
+            font-size: 14px !important;
+        }
+
+        .yaml-front-matter .yaml-label {
+            /* Inherits from summary */
+        }
+
         .yaml-front-matter table {
             width: 100% !important;
             border-collapse: collapse !important;

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -271,7 +271,7 @@ function renderYAMLFrontMatter(frontMatter) {
         if (Array.isArray(value)) {
             // Render arrays as a list
             const listItems = value.map(item => `<li>${escapeHtml(String(item))}</li>`).join('');
-            escapedValue = `<ul style="margin: 0; padding-left: 20px;">${listItems}</ul>`;
+            escapedValue = `<ul>${listItems}</ul>`;
         } else if (typeof value === 'object' && value !== null) {
             // Render objects as nested key-value pairs
             const nested = Object.entries(value)
@@ -283,17 +283,17 @@ function renderYAMLFrontMatter(frontMatter) {
         }
 
         tableRows += `<tr>
-            <td style="font-weight: 600; padding: 8px 12px; vertical-align: top; border-bottom: 1px solid rgba(0,0,0,0.1);">${escapedKey}</td>
-            <td style="padding: 8px 12px; vertical-align: top; border-bottom: 1px solid rgba(0,0,0,0.1);">${escapedValue}</td>
+            <td>${escapedKey}</td>
+            <td>${escapedValue}</td>
         </tr>`;
     }
 
-    return `<details class="yaml-front-matter" style="margin: 20px 0; border: 1px solid rgba(0,0,0,0.15); border-radius: 6px; background: rgba(0,0,0,0.02); overflow: hidden;">
-        <summary style="padding: 12px 16px; cursor: pointer; font-weight: 600; background: rgba(0,0,0,0.05); user-select: none; display: flex; align-items: center; gap: 8px;">
-            <span style="font-size: 14px;">📋</span>
-            <span>Document Metadata</span>
+    return `<details class="yaml-front-matter">
+        <summary>
+            <span class="yaml-icon">📋</span>
+            <span class="yaml-label">Document Metadata</span>
         </summary>
-        <table style="width: 100%; border-collapse: collapse; margin: 0; font-size: 14px;">
+        <table>
             ${tableRows}
         </table>
     </details>`;


### PR DESCRIPTION
## Summary
- Removes inline styles from YAML front matter rendering
- Moves all styling to CSS classes in index.html
- Follows DRY principles and codebase patterns

## Changes
- Updated js/renderer.js - removed inline styles from renderYAMLFrontMatter()
- Updated index.html - added CSS classes for yaml-icon and yaml-label elements

## Details
The `renderYAMLFrontMatter()` function previously had inline styles that duplicated CSS already present in index.html. This refactor:

1. **In js/renderer.js:**
   - Removed all `style="..."` attributes from generated HTML
   - Added semantic CSS classes: `.yaml-icon` and `.yaml-label`
   - Simplified the HTML structure to rely on CSS classes

2. **In index.html:**
   - Added `.yaml-icon` class for the icon element
   - Added `.yaml-label` class for the label element (currently inherits from summary)
   - Existing `.yaml-front-matter` CSS already covered most styling needs

## Testing
- All existing YAML front matter rendering continues to work correctly
- No visual changes to the output
- Styling is now centralized in CSS, improving maintainability

Fixes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)