### PR TITLE
refactor: Move Learn More link inline styles to CSS class (fixes #238)

### DIFF
--- a/index.html
+++ b/index.html
@@ -500,6 +500,11 @@
             border-color: #2ecc71;
         }
 
+        .private-url-modal .learn-more-container {
+            margin: 8px 0 12px 0;
+            font-size: 12px;
+        }
+
         .private-url-modal .learn-more-link {
             color: #3498db;
             text-decoration: none;
@@ -1149,7 +1154,7 @@
             <div class="security-icon" aria-hidden="true">🔒</div>
             <h2 id="privateUrlModalTitle">Private Repository Detected</h2>
             <p id="privateUrlModalDesc">This URL contains a private access token. To protect your security, choose how you'd like to proceed:</p>
-            <p style="margin: 8px 0 12px 0; font-size: 12px;"><a href="/?url=SECURITY.md#private-repository-token-protection" target="_blank" rel="noopener noreferrer" class="learn-more-link">Learn more about private repo tokens</a></p>
+            <p class="learn-more-container"><a href="/?url=SECURITY.md#private-repository-token-protection" target="_blank" rel="noopener noreferrer" class="learn-more-link">Learn more about private repo tokens</a></p>
             <div class="option-buttons">
                 <button class="option-btn" data-action="view-local" type="button" aria-label="View Locally Only - Render content without a shareable URL">
                     <span class="option-title">View Locally Only</span>


### PR DESCRIPTION
## Summary
- Moves inline styles from Learn More link to CSS class
- Follows codebase patterns for styling

## Changes
- Updated index.html - added CSS class and removed inline styles

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)