### PR TITLE
test: Add comprehensive CJK/Japanese character support tests (fixes #247)

### DIFF
--- a/tests/i18n-cjk-support.spec.js
+++ b/tests/i18n-cjk-support.spec.js
@@ -471,10 +471,8 @@ greeting: "Hello こんにちは 你好 안녕하세요"
           return globalThis.isAllowedMarkdownURL(testUrl);
         }, url);
 
-        // Note: The current implementation blocks non-ASCII hostnames but should allow
-        // non-ASCII path components. However, the actual validation might vary.
-        // This test documents the current behavior.
-        expect(typeof isAllowed).toBe('boolean');
+        // CJK characters in URL paths should be allowed (they get percent-encoded by browser)
+        expect(isAllowed).toBe(true);
       }
     });
 
@@ -783,6 +781,10 @@ ${longJapanese}`;
       // Verify long string is preserved
       expect(html).toContain('あ'.repeat(100)); // Check for substantial portion
       expect(html.length).toBeGreaterThan(1000);
+
+      // Verify content wasn't truncated
+      const charCount = (html.match(/あ/g) || []).length;
+      expect(charCount).toBe(1000);
     });
 
     test('handles mixed directionality (LTR CJK with RTL markers)', async ({ page }) => {


### PR DESCRIPTION
## Summary
Adds comprehensive test suite for Japanese/Chinese/Korean character support, ensuring that Merview properly handles all CJK languages and prevents XSS attacks with CJK characters.

## Changes
- **New**: tests/i18n-cjk-support.spec.js (880 lines, 33 tests)

## Test Coverage

### Content Rendering (9 tests)
- ✅ Japanese text (hiragana, katakana, kanji)
- ✅ Chinese text (simplified and traditional)
- ✅ Korean text (hangul)
- ✅ Mixed ASCII/CJK content
- ✅ CJK in code blocks, blockquotes, lists, and tables

### YAML Front Matter (4 tests)
- ✅ Japanese values in YAML
- ✅ Chinese values in YAML
- ✅ Korean values in YAML
- ✅ Mixed CJK values in YAML

### URL Loading (4 tests)
- ✅ CJK characters in URL paths
- ✅ Homograph attack prevention (Cyrillic vs Latin)
- ✅ IDN homograph attacks blocked
- ✅ Legitimate ASCII domains allowed

### XSS Prevention with CJK (6 tests)
- ✅ Blocks script tags with CJK content
- ✅ Blocks event handlers with CJK
- ✅ Blocks encoded CJK XSS attempts
- ✅ Preserves legitimate CJK content
- ✅ Sanitizes YAML values with CJK
- ✅ Handles combining characters safely

### Mermaid Diagrams (3 tests)
- ✅ Renders diagrams with CJK labels
- ✅ Blocks XSS in Mermaid with CJK
- ✅ Mixed CJK and ASCII in diagrams

### Edge Cases (7 tests)
- ✅ Full-width punctuation and symbols
- ✅ Emoji mixed with CJK
- ✅ Very long CJK strings (1000+ characters)
- ✅ Mixed text directionality
- ✅ Rare and archaic CJK characters
- ✅ Unicode normalization forms
- ✅ CJK preservation across all contexts

## Test Results
All 33 tests passing ✅

## Related Issues
Fixes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>