### PR TITLE
fix: Isolate Mermaid diagrams from preview theme typography

### DIFF
--- a/index.html
+++ b/index.html
@@ -697,12 +697,12 @@
          * Without this isolation, theme properties cascade into SVG text elements,
          * causing Mermaid to miscalculate bounding boxes and render incorrectly.
          * See: https://github.com/mickdarling/merview/issues/172
-         * See: https://github.com/mick-warehime/markdown-mermaid-renderer/issues/342
+         * See: https://github.com/mickdarling/merview/issues/342
          */
         #wrapper .mermaid,
         .mermaid {
             line-height: 1;
-            font-size: 16px;
+            font-size: 1rem;
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             letter-spacing: normal;
             word-spacing: normal;


### PR DESCRIPTION
## Summary
- Fixes Mermaid diagram rendering issues when Academic and Newspaper themes are applied
- Uses `#wrapper .mermaid` selector for proper CSS specificity over theme styles
- Resets all typography properties (font-size, font-family, letter-spacing, etc.) that affect SVG rendering

## Test plan
- [x] All 1052 existing tests pass
- [x] `mermaid-text-clipping.spec.js` tests specifically verify isolation
- [ ] Manual verification: Load mermaid-diagrams.md with Academic theme
- [ ] Manual verification: Load mermaid-diagrams.md with Newspaper theme

Fixes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)