### PR TITLE
fix: Prevent theme CSS from breaking Mermaid flowchart rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -693,9 +693,9 @@
 
         /*
          * Isolate Mermaid diagrams from preview theme typography.
-         * Uses #wrapper prefix for specificity to override theme styles.
-         * Without this isolation, theme properties cascade into SVG text elements,
-         * causing Mermaid to miscalculate bounding boxes and render incorrectly.
+         * Primary fix: htmlLabels:false directive injected in renderer.js forces
+         * SVG text instead of foreignObject HTML, preventing CSS inheritance.
+         * This CSS provides additional isolation for SVG text elements.
          * See: https://github.com/mickdarling/merview/issues/172
          * See: https://github.com/mickdarling/merview/issues/342
          */
@@ -777,7 +777,7 @@
             white-space: pre-wrap;
         }
 
-        /* Ensure SVG text elements don't inherit conflicting typography - Issue #342 */
+        /* Ensure SVG text elements don't inherit conflicting typography */
         #wrapper .mermaid svg,
         #wrapper .mermaid svg text,
         #wrapper .mermaid svg tspan,

--- a/tests/mermaid-text-clipping.spec.js
+++ b/tests/mermaid-text-clipping.spec.js
@@ -5,9 +5,16 @@
 const { test, expect } = require('@playwright/test');
 
 /**
- * Tests for Mermaid diagram text clipping fix (Issue #172)
+ * Tests for Mermaid diagram text clipping fix (Issue #342)
  * Verifies that SVG text elements are not clipped due to CSS inheritance
  */
+
+// Timeout constants for consistent test timing
+const TIMEOUTS = {
+    PAGE_LOAD: 1000,
+    MERMAID_RENDER: 2000,
+    THEME_SWITCH: 1500
+};
 
 test.describe('Mermaid text clipping fix', () => {
     const mermaidContent = `# Test Diagram
@@ -24,7 +31,7 @@ graph LR
 
     test.beforeEach(async ({ page }) => {
         await page.goto('/');
-        await page.waitForTimeout(1000);
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
 
         // Set content with Mermaid diagram
         await page.evaluate((content) => {
@@ -34,7 +41,7 @@ graph LR
         }, mermaidContent);
 
         // Wait for Mermaid to render
-        await page.waitForTimeout(2000);
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
     });
 
     test('mermaid container should have line-height isolation', async ({ page }) => {
@@ -87,7 +94,7 @@ graph LR
                 globalThis.changeStyle('monospace');
             }
         });
-        await page.waitForTimeout(1500);
+        await page.waitForTimeout(TIMEOUTS.THEME_SWITCH);
 
         // Verify line-height on mermaid container is still isolated
         const lineHeight = await mermaidDiv.evaluate((el) => {
@@ -114,7 +121,7 @@ graph LR
                 globalThis.changeStyle('academic');
             }
         });
-        await page.waitForTimeout(1500);
+        await page.waitForTimeout(TIMEOUTS.THEME_SWITCH);
 
         // Verify typography properties are isolated from Academic theme
         const styles = await mermaidDiv.evaluate((el) => {
@@ -148,7 +155,7 @@ graph LR
                 globalThis.changeStyle('newspaper');
             }
         });
-        await page.waitForTimeout(1500);
+        await page.waitForTimeout(TIMEOUTS.THEME_SWITCH);
 
         // Verify typography properties are isolated from Newspaper theme
         const styles = await mermaidDiv.evaluate((el) => {
@@ -182,7 +189,7 @@ graph LR
                 globalThis.changeStyle('academic');
             }
         });
-        await page.waitForTimeout(1500);
+        await page.waitForTimeout(TIMEOUTS.THEME_SWITCH);
 
         // Check SVG element styles (text elements may be nested deep)
         const svgStyles = await mermaidSvg.evaluate((el) => {
@@ -197,5 +204,374 @@ graph LR
         // SVG should have isolated typography
         expect(svgStyles.letterSpacing).toBe('normal');
         expect(svgStyles.textTransform).toBe('none');
+    });
+
+    // Issue #342 - Verify htmlLabels: false directive enables SVG text elements
+    test('flowcharts should have SVG text elements for node labels', async ({ page }) => {
+        // Wait for mermaid SVG to fully render
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Verify flowcharts have native SVG text elements (htmlLabels: false enables this)
+        // Note: Mermaid may still use foreignObject for some elements (e.g., edge labels),
+        // but the key fix is that node labels use SVG text which avoids CSS inheritance issues
+        const textCount = await mermaidSvg.evaluate((svg) => {
+            return svg.querySelectorAll('text').length;
+        });
+
+        expect(textCount).toBeGreaterThan(0); // Should have SVG text elements for labels
+    });
+
+    test('flowchart text should be fully visible (not clipped) with Academic theme', async ({ page }) => {
+        // Wait for mermaid SVG to fully render
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Switch to Academic style
+        await page.evaluate(() => {
+            if (globalThis.changeStyle) {
+                globalThis.changeStyle('academic');
+            }
+        });
+        await page.waitForTimeout(TIMEOUTS.THEME_SWITCH);
+
+        // Get all text from the SVG (both <text> elements and foreignObject content)
+        const textContent = await mermaidSvg.evaluate((svg) => {
+            // Get text from <text> elements
+            const svgTexts = Array.from(svg.querySelectorAll('text'))
+                .map(t => t.textContent?.trim()).filter(Boolean);
+            // Get text from foreignObject elements
+            const foTexts = Array.from(svg.querySelectorAll('foreignObject'))
+                .map(fo => fo.textContent?.trim()).filter(Boolean);
+            return [...svgTexts, ...foTexts];
+        });
+
+        // Should have readable text labels
+        expect(textContent.length).toBeGreaterThan(0);
+
+        // Verify known labels are present and complete (not truncated)
+        const allText = textContent.join(' ');
+        expect(allText).toContain('Markdown');
+        expect(allText).toContain('Parser');
+        expect(allText).toContain('Renderer');
+    });
+
+    test('flowchart text should be fully visible (not clipped) with Newspaper theme', async ({ page }) => {
+        // Wait for mermaid SVG to fully render
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Switch to Newspaper style (font-size: 14px, font-family: Times New Roman)
+        await page.evaluate(() => {
+            if (globalThis.changeStyle) {
+                globalThis.changeStyle('newspaper');
+            }
+        });
+        await page.waitForTimeout(TIMEOUTS.THEME_SWITCH);
+
+        // Get all text from the SVG
+        const textContent = await mermaidSvg.evaluate((svg) => {
+            const svgTexts = Array.from(svg.querySelectorAll('text'))
+                .map(t => t.textContent?.trim()).filter(Boolean);
+            const foTexts = Array.from(svg.querySelectorAll('foreignObject'))
+                .map(fo => fo.textContent?.trim()).filter(Boolean);
+            return [...svgTexts, ...foTexts];
+        });
+
+        // Should have readable text labels
+        expect(textContent.length).toBeGreaterThan(0);
+
+        // Verify known labels are present and complete (not truncated)
+        const allText = textContent.join(' ');
+        expect(allText).toContain('Markdown');
+        expect(allText).toContain('Parser');
+        expect(allText).toContain('Renderer');
+    });
+});
+
+test.describe('Mermaid diagrams with existing init directives', () => {
+    test('diagram with existing init directive should still render correctly', async ({ page }) => {
+        const contentWithDirective = `# Test with existing directive
+
+\`\`\`mermaid
+%%{init: {"theme": "forest"}}%%
+graph LR
+    A[Start] --> B[End]
+\`\`\`
+`;
+        await page.goto('/');
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
+
+        await page.evaluate((content) => {
+            if (globalThis.setEditorContent) {
+                globalThis.setEditorContent(content);
+            }
+        }, contentWithDirective);
+
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
+
+        // Verify diagram rendered correctly
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Verify it has rendered content (text in some form)
+        const hasContent = await mermaidSvg.evaluate((svg) => {
+            const texts = svg.querySelectorAll('text');
+            const foreignObjects = svg.querySelectorAll('foreignObject');
+            return texts.length > 0 || foreignObjects.length > 0;
+        });
+
+        expect(hasContent).toBe(true);
+    });
+
+    test('diagram with existing flowchart config should still render correctly', async ({ page }) => {
+        const contentWithFlowchartConfig = `# Test with flowchart config
+
+\`\`\`mermaid
+%%{init: {"flowchart": {"curve": "basis"}}}%%
+graph LR
+    A[Node A] --> B[Node B]
+    B --> C[Node C]
+\`\`\`
+`;
+        await page.goto('/');
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
+
+        await page.evaluate((content) => {
+            if (globalThis.setEditorContent) {
+                globalThis.setEditorContent(content);
+            }
+        }, contentWithFlowchartConfig);
+
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
+
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Verify the diagram rendered with readable labels
+        const textContent = await mermaidSvg.evaluate((svg) => {
+            const svgTexts = Array.from(svg.querySelectorAll('text'))
+                .map(t => t.textContent?.trim()).filter(Boolean);
+            const foTexts = Array.from(svg.querySelectorAll('foreignObject'))
+                .map(fo => fo.textContent?.trim()).filter(Boolean);
+            return [...svgTexts, ...foTexts].join(' ');
+        });
+
+        expect(textContent).toContain('Node A');
+        expect(textContent).toContain('Node B');
+    });
+
+    test('diagram with empty flowchart config should still render correctly', async ({ page }) => {
+        // Edge case: empty flowchart object - tests JSON parsing robustness
+        const contentWithEmptyConfig = `# Test with empty flowchart config
+
+\`\`\`mermaid
+%%{init: {"flowchart": {}}}%%
+graph LR
+    A[Empty Config] --> B[Still Works]
+\`\`\`
+`;
+        await page.goto('/');
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
+
+        await page.evaluate((content) => {
+            if (globalThis.setEditorContent) {
+                globalThis.setEditorContent(content);
+            }
+        }, contentWithEmptyConfig);
+
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
+
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Verify the diagram rendered correctly
+        const textContent = await mermaidSvg.evaluate((svg) => {
+            const svgTexts = Array.from(svg.querySelectorAll('text'))
+                .map(t => t.textContent?.trim()).filter(Boolean);
+            const foTexts = Array.from(svg.querySelectorAll('foreignObject'))
+                .map(fo => fo.textContent?.trim()).filter(Boolean);
+            return [...svgTexts, ...foTexts].join(' ');
+        });
+
+        expect(textContent).toContain('Empty Config');
+        expect(textContent).toContain('Still Works');
+    });
+
+    test('diagram with malformed init directive should still render', async ({ page }) => {
+        // Edge case: invalid JSON in directive - should fall back to prepending
+        const contentWithMalformed = `# Test malformed directive
+
+\`\`\`mermaid
+%%{init: {"flowchart": {curve: "basis"}}}%%
+graph LR
+    A[Malformed] --> B[Still Renders]
+\`\`\`
+`;
+        await page.goto('/');
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
+
+        await page.evaluate((content) => {
+            if (globalThis.setEditorContent) {
+                globalThis.setEditorContent(content);
+            }
+        }, contentWithMalformed);
+
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
+
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Should fall back to prepending directive and still render
+        const textContent = await mermaidSvg.evaluate((svg) => {
+            const svgTexts = Array.from(svg.querySelectorAll('text'))
+                .map(t => t.textContent?.trim()).filter(Boolean);
+            const foTexts = Array.from(svg.querySelectorAll('foreignObject'))
+                .map(fo => fo.textContent?.trim()).filter(Boolean);
+            return [...svgTexts, ...foTexts].join(' ');
+        });
+
+        expect(textContent).toContain('Malformed');
+        expect(textContent).toContain('Still Renders');
+    });
+
+    test('diagram with whitespace in directive should still render', async ({ page }) => {
+        // Edge case: tabs and extra whitespace in directive - tests regex robustness
+        const contentWithWhitespace = `# Test whitespace in directive
+
+\`\`\`mermaid
+%%{init:	{"theme": "default"}	}%%
+graph LR
+    A[Tabs Work] --> B[Spaces Too]
+\`\`\`
+`;
+        await page.goto('/');
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
+
+        await page.evaluate((content) => {
+            if (globalThis.setEditorContent) {
+                globalThis.setEditorContent(content);
+            }
+        }, contentWithWhitespace);
+
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
+
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Verify the diagram rendered correctly with whitespace in directive
+        const textContent = await mermaidSvg.evaluate((svg) => {
+            const svgTexts = Array.from(svg.querySelectorAll('text'))
+                .map(t => t.textContent?.trim()).filter(Boolean);
+            const foTexts = Array.from(svg.querySelectorAll('foreignObject'))
+                .map(fo => fo.textContent?.trim()).filter(Boolean);
+            return [...svgTexts, ...foTexts].join(' ');
+        });
+
+        expect(textContent).toContain('Tabs Work');
+        expect(textContent).toContain('Spaces Too');
+    });
+});
+
+test.describe('Other diagram types still work correctly', () => {
+    test('sequenceDiagram should render correctly', async ({ page }) => {
+        const sequenceContent = `# Sequence Diagram Test
+
+\`\`\`mermaid
+sequenceDiagram
+    Alice->>Bob: Hello Bob
+    Bob->>Alice: Hi Alice
+\`\`\`
+`;
+        await page.goto('/');
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
+
+        await page.evaluate((content) => {
+            if (globalThis.setEditorContent) {
+                globalThis.setEditorContent(content);
+            }
+        }, sequenceContent);
+
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
+
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Sequence diagrams naturally use SVG text
+        const textElements = await mermaidSvg.evaluate((svg) => {
+            return svg.querySelectorAll('text').length;
+        });
+
+        expect(textElements).toBeGreaterThan(0);
+    });
+
+    test('classDiagram should render correctly', async ({ page }) => {
+        const classContent = `# Class Diagram Test
+
+\`\`\`mermaid
+classDiagram
+    Animal <|-- Duck
+    Animal : +int age
+    Duck : +String beakColor
+\`\`\`
+`;
+        await page.goto('/');
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
+
+        await page.evaluate((content) => {
+            if (globalThis.setEditorContent) {
+                globalThis.setEditorContent(content);
+            }
+        }, classContent);
+
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
+
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Should have rendered content (class diagrams may use text or foreignObject)
+        const textContent = await mermaidSvg.evaluate((svg) => {
+            const svgTexts = Array.from(svg.querySelectorAll('text'))
+                .map(t => t.textContent?.trim()).filter(Boolean);
+            const foTexts = Array.from(svg.querySelectorAll('foreignObject'))
+                .map(fo => fo.textContent?.trim()).filter(Boolean);
+            return [...svgTexts, ...foTexts].join(' ');
+        });
+
+        // Verify class names are present
+        expect(textContent).toContain('Animal');
+        expect(textContent).toContain('Duck');
+    });
+
+    test('stateDiagram should render correctly', async ({ page }) => {
+        const stateContent = `# State Diagram Test
+
+\`\`\`mermaid
+stateDiagram-v2
+    [*] --> Active
+    Active --> Inactive
+    Inactive --> [*]
+\`\`\`
+`;
+        await page.goto('/');
+        await page.waitForTimeout(TIMEOUTS.PAGE_LOAD);
+
+        await page.evaluate((content) => {
+            if (globalThis.setEditorContent) {
+                globalThis.setEditorContent(content);
+            }
+        }, stateContent);
+
+        await page.waitForTimeout(TIMEOUTS.MERMAID_RENDER);
+
+        const mermaidSvg = page.locator('.mermaid svg').first();
+        await expect(mermaidSvg).toBeVisible({ timeout: 10000 });
+
+        // Should have rendered
+        const hasContent = await mermaidSvg.evaluate((svg) => {
+            return svg.innerHTML.length > 100;
+        });
+
+        expect(hasContent).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary

- Inject `%%{init: {"flowchart": {"htmlLabels": false}}}%%` directive into Mermaid diagrams before rendering
- Forces SVG `<text>` elements instead of `<foreignObject>` HTML, preventing CSS inheritance from themes
- Fixes text clipping in flowcharts when using Academic, Newspaper, or custom themes with serif fonts

## Root Cause

Themes like Academic and Newspaper set custom `font-family` and `font-size` on `#wrapper`. This cascaded into `<foreignObject>` HTML content inside Mermaid flowcharts. Mermaid calculates node bounding boxes based on text dimensions at render time, but CSS inheritance caused text to render at different sizes than calculated, resulting in clipped/truncated labels.

`sequenceDiagram` was unaffected because it already uses native SVG `<text>` elements which don't inherit CSS from the parent document the same way.

Fixes #342

## Test plan

- [x] All 1072 tests pass
- [x] Lint passes
- [ ] Manual test: Load welcome.md with Academic theme - flowcharts should render correctly
- [ ] Manual test: Load welcome.md with Newspaper theme - flowcharts should render correctly
- [ ] Manual test: Verify sequenceDiagram still renders correctly
- [ ] Manual test: Test with custom CSS loaded via file import

🤖 Generated with [Claude Code](https://claude.com/claude-code)