### PR TITLE
fix: Isolate Mermaid diagrams from theme drop cap and typography styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -711,6 +711,36 @@
             font-weight: normal;
         }
 
+        /* Prevent theme drop cap styles from bleeding into Mermaid foreignObject content */
+        #wrapper .mermaid *::first-letter,
+        .mermaid *::first-letter {
+            float: none !important;
+            font-size: inherit !important;
+            line-height: inherit !important;
+            margin: 0 !important;
+            font-weight: inherit !important;
+        }
+
+        /* Reset all typography inside Mermaid foreignObject elements */
+        #wrapper .mermaid foreignObject *,
+        .mermaid foreignObject * {
+            font-size: inherit !important;
+            font-family: inherit !important;
+            font-weight: normal !important;
+            font-style: normal !important;
+            letter-spacing: normal !important;
+            word-spacing: normal !important;
+            text-transform: none !important;
+            line-height: 1.2 !important;
+        }
+
+        /* Edge label backgrounds - inherit from Mermaid's generated styles */
+        #wrapper .mermaid .edgeLabel rect,
+        .mermaid .edgeLabel rect {
+            fill: var(--mermaid-background, white) !important;
+            opacity: 1 !important;
+        }
+
         /* Mermaid loading state - Issue #326 */
         .mermaid-loading {
             min-height: 100px;


### PR DESCRIPTION
## Summary
- Block `::first-letter` drop cap styles from bleeding into Mermaid foreignObject content
- Reset typography inside Mermaid foreignObject elements  
- Ensure edge label rect backgrounds are fully opaque

## Problem
Academic and Newspaper themes have drop cap styling (`::first-letter` with large font-size and float) that was bleeding into Mermaid diagram text, causing the first letter of each node label to render as a giant character.

Additionally, edge labels had transparent backgrounds causing content to "ghost" through.

## Solution
CSS-only fix that:
1. Resets `::first-letter` pseudo-element styling inside `.mermaid` containers
2. Resets all typography inside Mermaid foreignObject elements
3. Forces edge label rect backgrounds to be fully opaque

## Test plan
- [x] Verify Mermaid diagrams render correctly with Academic theme
- [x] Verify Mermaid diagrams render correctly with Newspaper theme
- [x] Verify edge labels have opaque backgrounds (no ghosting)
- [x] Verify dark theme edge labels still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)