### PR TITLE
fix: Reset documentMode when clearing editor

### DIFF
--- a/js/components/sessions-modal.js
+++ b/js/components/sessions-modal.js
@@ -212,6 +212,8 @@ function clearEditor() {
         cmEditor.setValue('');
     }
     state.currentFilename = null;
+    state.documentMode = null; // Reset to auto-detect mode (#380 fix)
+    state.lastRenderedContent = null; // Clear to prevent stale optimization (#371)
     renderMarkdown();
 }
 
@@ -325,6 +327,8 @@ function handleClearAll() {
             cmEditor.setValue('');
         }
         state.currentFilename = 'Untitled';
+        state.documentMode = null; // Reset to auto-detect mode (#380 fix)
+        state.lastRenderedContent = null; // Clear to prevent stale optimization (#371)
         renderMarkdown();
 
         // Update displays

--- a/js/main.js
+++ b/js/main.js
@@ -31,6 +31,8 @@ function clearEditor() {
         }
         state.currentFilename = null;
         state.loadedFromURL = null;
+        state.documentMode = null; // Reset to auto-detect mode (#380 fix)
+        state.lastRenderedContent = null; // Clear to prevent stale optimization (#371)
 
         updateDocumentSelector();
         renderMarkdown();


### PR DESCRIPTION
## Summary
- Fixes mermaid-only content not rendering after clearing the editor
- When the welcome page loads, it sets `documentMode='markdown'`
- The `clearEditor` functions weren't resetting this state
- After clearing, pasted mermaid content was treated as markdown instead of being auto-detected

## Changes
- `js/main.js`: Reset `documentMode` and `lastRenderedContent` in `clearEditor()`
- `js/components/sessions-modal.js`: Same fix in `clearEditor()` and `handleClearAll()`

## Test plan
- [x] Load welcome page
- [x] Clear the editor
- [x] Paste pure mermaid content (e.g., `graph TD\n    A --> B`)
- [x] Verify diagram renders correctly
- [x] All existing mermaid tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)