### PR TITLE
fix: CSS scoping bypass when stylesheets contain #wrapper selector

### DIFF
--- a/js/themes.js
+++ b/js/themes.js
@@ -266,8 +266,8 @@ function stripPrintMediaQueries(css) {
 function isSelectorScoped(selector) {
     // Match #wrapper or #preview as complete selectors (with word boundaries)
     // This prevents false matches like #wrapper-container or #preview-panel
-    return /(?:^|[\s,>+~])#wrapper(?:$|[\s,.:#>\[+~])/.test(selector) ||
-           /(?:^|[\s,>+~])#preview(?:$|[\s,.:#>\[+~])/.test(selector);
+    return /(?:^|[\s,>+~])#wrapper(?:$|[\s,.:#>[+~])/.test(selector) ||
+           /(?:^|[\s,>+~])#preview(?:$|[\s,.:#>[+~])/.test(selector);
 }
 
 /**
@@ -296,7 +296,7 @@ function scopeSelector(selector) {
         return '#wrapper *';
     }
     // Handle compound selectors starting with :root, body, html (e.g., "body.dark", ":root[data-theme]")
-    if (/^(:root|body|html)([.#\[:].*)$/.test(trimmed)) {
+    if (/^(:root|body|html)([.#[:].*)$/.test(trimmed)) {
         return trimmed.replace(/^(:root|body|html)/, '#wrapper');
     }
     // Prefix with #wrapper


### PR DESCRIPTION
## Summary

- Fixes CSS scoping bypass bug where external stylesheets with ANY `#wrapper` rule would have their entire scoping skipped
- Adds word-boundary regex matching to correctly identify already-scoped selectors
- Enhances `scopeSelector()` to handle `:root`, `*`, and compound selectors like `body.dark`
- Adds comprehensive test suite with 17 tests covering all four theme dropdown selectors

Fixes #384

## Problem

When loading external CSS files (from file, URL, or MarkedCustomStyles), global selectors like `:root`, `*`, `body`, and `html` were affecting the entire Merview UI (editor, header, toolbar, footer) instead of just the `#wrapper` preview area.

## Root Cause

In `js/themes.js:532`, the check:
```javascript
if (style.source !== 'local' && !cssText.includes('#wrapper')) {
    cssText = scopeCSSToPreview(cssText);
}
```

This caused scoping to be completely bypassed if the CSS contained even ONE `#wrapper` rule.

## Solution

1. **Remove faulty bypass check** - Always scope non-local CSS (line 557)
2. **Add `isSelectorScoped()` function** - Uses word-boundary regex to avoid false positives like `#wrapper-container`
3. **Enhance `scopeSelector()`** - Now handles:
   - `:root` → `#wrapper`
   - `*` → `#wrapper *`
   - `body.dark`, `:root[data-theme]` → `#wrapper.dark`, `#wrapper[data-theme]`

## Test plan

- [x] New test file `tests/themes/css-scoping.spec.js` with 17 tests
- [x] Tests verify all four dropdown selectors apply CSS to correct targets only
- [x] Tests verify UI chrome (header, panel headers) are never affected
- [x] Full test suite passes (1237 passed, 23 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)